### PR TITLE
Update for Swift 3.1 / Xcode 8.3

### DIFF
--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -120,57 +120,67 @@ A video player implementation with basic functionality.
 	private func updateControls() {
 		videoPlayerControls.tintColor = tintColor
 		
-		videoPlayerControls.newVideo = {
-			if let videoURL = videoPlayerView.videoURL {
-				if let currentURLIndex = videoURLs.index(of: videoURL) {
-					videoPlayerControls.nextButtonHidden = currentURLIndex == videoURLs.count - 1
-					videoPlayerControls.previousButtonHidden = currentURLIndex == 0
+        videoPlayerControls.newVideo = { [weak self] in
+            guard let sSelf = self else { return }
+            
+			if let videoURL = sSelf.videoPlayerView.videoURL {
+				if let currentURLIndex = sSelf.videoURLs.index(of: videoURL) {
+					sSelf.videoPlayerControls.nextButtonHidden = currentURLIndex == sSelf.videoURLs.count - 1
+					sSelf.videoPlayerControls.previousButtonHidden = currentURLIndex == 0
 				}
 			}
 		}
 		
-		videoPlayerControls.finishedVideo = {
-			if let videoURL = videoPlayerView.videoURL {
-				if videoURL == videoURLs.last {
-					if videoPlayerView.shouldLoop == true {
-						videoPlayerView.videoURL = videoURLs.first
+        videoPlayerControls.finishedVideo = { [weak self] in
+            guard let sSelf = self else { return }
+            
+			if let videoURL = sSelf.videoPlayerView.videoURL {
+				if videoURL == sSelf.videoURLs.last {
+					if sSelf.videoPlayerView.shouldLoop == true {
+						sSelf.videoPlayerView.videoURL = sSelf.videoURLs.first
 					}
 				} else {
-					let currentURLIndex = videoURLs.index(of: videoURL)
-					let nextURL = videoURLs[currentURLIndex! + 1]
+					let currentURLIndex = sSelf.videoURLs.index(of: videoURL)
+					let nextURL = sSelf.videoURLs[currentURLIndex! + 1]
 					
-					videoPlayerView.videoURL = nextURL
+					sSelf.videoPlayerView.videoURL = nextURL
 				}
 			}
 		}
 		
-		videoPlayerControls.didPressNextButton = {
-			if let videoURL = videoPlayerView.videoURL {
-				if let currentURLIndex = videoURLs.index(of: videoURL), currentURLIndex + 1 < videoURLs.count {
-					let nextURL = videoURLs[currentURLIndex + 1]
+        videoPlayerControls.didPressNextButton = { [weak self] in
+            guard let sSelf = self else { return }
+            
+			if let videoURL = sSelf.videoPlayerView.videoURL {
+				if let currentURLIndex = sSelf.videoURLs.index(of: videoURL), currentURLIndex + 1 < sSelf.videoURLs.count {
+					let nextURL = sSelf.videoURLs[currentURLIndex + 1]
 					
-					videoPlayerView.videoURL = nextURL
+					sSelf.videoPlayerView.videoURL = nextURL
 				}
 			}
 		}
 		
-		videoPlayerControls.didPressPreviousButton = {
-			if let videoURL = videoPlayerView.videoURL {
-				if let currentURLIndex = videoURLs.index(of: videoURL), currentURLIndex > 0 {
-					let nextURL = videoURLs[currentURLIndex - 1]
+        videoPlayerControls.didPressPreviousButton = { [weak self] in
+            guard let sSelf = self else { return }
+            
+			if let videoURL = sSelf.videoPlayerView.videoURL {
+				if let currentURLIndex = sSelf.videoURLs.index(of: videoURL), currentURLIndex > 0 {
+					let nextURL = sSelf.videoURLs[currentURLIndex - 1]
 					
-					videoPlayerView.videoURL = nextURL
+					sSelf.videoPlayerView.videoURL = nextURL
 				}
 			}
 		}
 		
-		videoPlayerControls.interacting = { (isInteracting) in
-			NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
+		videoPlayerControls.interacting = { [weak self] (isInteracting) in
+            guard let sSelf = self else { return }
+            
+			NSObject.cancelPreviousPerformRequests(withTarget: sSelf, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
 			if isInteracting == true {
-				showControls()
+				sSelf.showControls()
 			} else {
-				if videoPlayerView.status == .playing {
-					perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
+				if sSelf.videoPlayerView.status == .playing {
+					sSelf.perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
 				}
 			}
 		}

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -120,12 +120,12 @@ Base class for the video controls.
 open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControls {
 	@IBOutlet open weak var videoPlayer: ASPVideoPlayerView?
 	
-	open var didPressNextButton: (@noescape () -> Void)?
-	open var didPressPreviousButton: (@noescape () -> Void)?
+	open var didPressNextButton: (() -> Void)?
+	open var didPressPreviousButton: (() -> Void)?
 	
-	open var interacting: (@noescape (Bool) -> Void)?
-	open var newVideo: (@noescape () -> Void)?
-	open var finishedVideo: (@noescape () -> Void)?
+	open var interacting: ((Bool) -> Void)?
+	open var newVideo: (() -> Void)?
+	open var finishedVideo: (() -> Void)?
 	
 	open var nextButtonHidden: Bool = true
 	open var previousButtonHidden: Bool = true
@@ -263,68 +263,84 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	
 	private func setupVideoPlayerView() {
 		if let videoPlayerView = videoPlayer {
-			videoPlayerView.newVideo = {
-				newVideo?()
+			videoPlayerView.newVideo = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.newVideo?()
 				
-				progressSlider.isUserInteractionEnabled = false
+				sSelf.progressSlider.isUserInteractionEnabled = false
 				
-				progressLoader.startAnimating()
-				progressSlider.value = 0.0
+				sSelf.progressLoader.startAnimating()
+				sSelf.progressSlider.value = 0.0
 				
-				lengthLabel.text = timeFormatted(totalSeconds: 0)
-				currentTimeLabel.text = timeFormatted(totalSeconds: 0)
+				sSelf.lengthLabel.text = sSelf.timeFormatted(totalSeconds: 0)
+				sSelf.currentTimeLabel.text = sSelf.timeFormatted(totalSeconds: 0)
 				
-				progressLoader.startAnimating()
+				sSelf.progressLoader.startAnimating()
 			}
 			
-			videoPlayerView.readyToPlayVideo = {
-				progressSlider.isUserInteractionEnabled = true
+            videoPlayerView.readyToPlayVideo = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.progressSlider.isUserInteractionEnabled = true
 				
 				let currentTime = videoPlayerView.currentTime
-				lengthLabel.text = timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
-				currentTimeLabel.text = timeFormatted(totalSeconds: UInt(currentTime))
+				sSelf.lengthLabel.text = sSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
+				sSelf.currentTimeLabel.text = sSelf.timeFormatted(totalSeconds: UInt(currentTime))
 				
-				progressLoader.stopAnimating()
+				sSelf.progressLoader.stopAnimating()
 			}
 			
-			videoPlayerView.playingVideo = { (progress) in
-				if isInteracting == false {
-					progressSlider.value = CGFloat(progress)
+			videoPlayerView.playingVideo = { [weak self] (progress) in
+                guard let sSelf = self else { return }
+                
+				if sSelf.isInteracting == false {
+					sSelf.progressSlider.value = CGFloat(progress)
 				}
 				
 				let currentTime = videoPlayerView.currentTime
-				currentTimeLabel.text = timeFormatted(totalSeconds: UInt(currentTime))
+				sSelf.currentTimeLabel.text = sSelf.timeFormatted(totalSeconds: UInt(currentTime))
 			}
 			
-			videoPlayerView.startedVideo = {
-				progressSlider.isUserInteractionEnabled = true
+            videoPlayerView.startedVideo = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.progressSlider.isUserInteractionEnabled = true
 				
 				let currentTime = videoPlayerView.currentTime
-				lengthLabel.text = timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
-				currentTimeLabel.text = timeFormatted(totalSeconds: UInt(currentTime))
+				sSelf.lengthLabel.text = sSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
+				sSelf.currentTimeLabel.text = sSelf.timeFormatted(totalSeconds: UInt(currentTime))
 				
-				progressLoader.stopAnimating()
+				sSelf.progressLoader.stopAnimating()
 			}
 			
-			videoPlayerView.stoppedVideo = {
-				playPauseButton.isSelected = false
-				progressSlider.value = 0.0
+            videoPlayerView.stoppedVideo = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.playPauseButton.isSelected = false
+				sSelf.progressSlider.value = 0.0
 			}
 			
-			videoPlayerView.finishedVideo = {
-				finishedVideo?()
+            videoPlayerView.finishedVideo = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.finishedVideo?()
 			}
 			
 			videoPlayerView.error = { (error) in
 				print(error)
 			}
 			
-			videoPlayerView.seekStarted = {
-				progressLoader.startAnimating()
+            videoPlayerView.seekStarted = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.progressLoader.startAnimating()
 			}
 			
-			videoPlayerView.seekEnded = {
-				progressLoader.stopAnimating()
+            videoPlayerView.seekEnded = { [weak self] in
+                guard let sSelf = self else { return }
+                
+				sSelf.progressLoader.stopAnimating()
 			}
 		}
 	}

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -20,19 +20,19 @@ A simple UIView subclass that can play a video and allows animations to be appli
 	/**
 	Basic closure type.
 	*/
-	public typealias VoidClosure = (@noescape () -> Void)?
+	public typealias VoidClosure = (() -> Void)?
 	
 	/**
 	Closure type for recurring actions.
 	- Parameter progress: The progress indicator value. Value is in range [0.0, 1.0].
 	*/
-	public typealias ProgressClosure = (@noescape (_ progress: Double) -> Void)?
+	public typealias ProgressClosure = ((_ progress: Double) -> Void)?
 	
 	/**
 	Closure type for error handling.
 	- Parameter error: The error that occured.
 	*/
-	public typealias ErrorClosure = (@noescape (_ error: NSError) -> Void)?
+	public typealias ErrorClosure = ((_ error: NSError) -> Void)?
 	
 	//MARK: - Enumerations -
 	

--- a/ASPVideoPlayer/Classes/Loader.swift
+++ b/ASPVideoPlayer/Classes/Loader.swift
@@ -55,7 +55,7 @@ open class Loader: UIView {
 		let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
 		rotationAnimation.duration = 4.0
 		rotationAnimation.fromValue = 0.0
-		rotationAnimation.toValue = 2 * M_PI
+		rotationAnimation.toValue = 2 * Double.pi
 		rotationAnimation.repeatCount = .infinity
 		progressLayer.add(rotationAnimation, forKey: "rotationAnimation")
 		
@@ -105,7 +105,7 @@ open class Loader: UIView {
 	
 	private func updatePath() {
 		let startAngle: CGFloat = 0.0
-		let endAngle: CGFloat = CGFloat(2.0 * M_PI)
+		let endAngle: CGFloat = CGFloat(2.0 * Double.pi)
 		let radius: CGFloat = min(bounds.size.width / 2.0, bounds.size.height / 2.0)
 		let path = UIBezierPath(arcCenter: CGPoint(x: bounds.midX, y: bounds.midY), radius: radius - lineWidth / 2.0, startAngle: startAngle, endAngle: endAngle, clockwise: true)
 		

--- a/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
+++ b/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -742,6 +742,7 @@
 				75C633301E056478000DBD42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
+++ b/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/ASPVideoPlayer/ViewController.swift
+++ b/Example/ASPVideoPlayer/ViewController.swift
@@ -42,28 +42,30 @@ class ViewController: UIViewController {
 			
 		}
 		
-		videoPlayer.finishedVideo = {
+        videoPlayer.finishedVideo = { [weak self] in
+            guard let sSelf = self else { return }
+            
 			print("finishedVideo")
-			if videoPlayer.videoURL == firstVideoURL {
-				videoPlayer.startPlayingWhenReady = true
-				videoPlayer.videoURL = secondVideoURL
+            if sSelf.videoPlayer.videoURL == sSelf.firstVideoURL {
+				sSelf.videoPlayer.startPlayingWhenReady = true
+				sSelf.videoPlayer.videoURL = sSelf.secondVideoURL
 			}
 			
 			UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
-				self.videoTopConstraint.constant = 150.0
-				self.videoBottomConstraint.constant = 150.0
-				self.videoLeadingConstraint.constant = 150.0
-				self.videoTrailingConstraint.constant = 150.0
-				self.view.layoutIfNeeded()
+				sSelf.videoTopConstraint.constant = 150.0
+				sSelf.videoBottomConstraint.constant = 150.0
+				sSelf.videoLeadingConstraint.constant = 150.0
+				sSelf.videoTrailingConstraint.constant = 150.0
+				sSelf.view.layoutIfNeeded()
 				}, completion: { (finished) in
 					UIView.animate(withDuration: 0.3, delay: 1.0, options: .curveEaseIn, animations: {
 						
-						self.videoTopConstraint.constant = 0.0
-						self.videoBottomConstraint.constant = 0.0
-						self.videoLeadingConstraint.constant = 0.0
-						self.videoTrailingConstraint.constant = 0.0
+						sSelf.videoTopConstraint.constant = 0.0
+						sSelf.videoBottomConstraint.constant = 0.0
+						sSelf.videoLeadingConstraint.constant = 0.0
+						sSelf.videoTrailingConstraint.constant = 0.0
 						
-						self.view.layoutIfNeeded()
+						sSelf.view.layoutIfNeeded()
 						}, completion: { (finished) in
 							
 					})


### PR DESCRIPTION
Great work on this; it's really cleanly abstracted and easy to follow with the closure callbacks.

I updated some areas where you were holding strongly onto `self` and also removed some warnings in Swift 3.1 / Xcode 8.3.

- [x] All tests are passing locally
