### PR TITLE
Async, retain cycles, tests, buffering and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@
 # * http://www.objc.io/issue-6/travis-ci.html
 # * https://github.com/supermarin/xcpretty#usage
 
-osx_image: xcode8.1
+osx_image: xcode8.3
 language: objective-c
 
 before_install:
   # Fix Travis  xcodebuild exited with 65 https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 6 (10.1" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 6 (10.3" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
   
@@ -18,7 +18,7 @@ before_install:
 - pod install --project-directory=Example
 script:
 - set -o pipefail
-- travis_retry xcodebuild -workspace 'Example/ASPVideoPlayer.xcworkspace' -scheme 'ASPVideoPlayer-Example' -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=10.0,name=iPhone 6s' -enableCodeCoverage YES build test | xcpretty -c
+- travis_retry xcodebuild -workspace 'Example/ASPVideoPlayer.xcworkspace' -scheme 'ASPVideoPlayer-Example' -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=10.3,name=iPhone 6s' -enableCodeCoverage YES build test | xcpretty -c
 - pod lib lint --allow-warnings
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'ASPVideoPlayer'

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -24,7 +24,6 @@ import UIKit
      */
     open var videoPlayerControls: ASPBasicControls? {
         didSet {
-            videoPlayerControls?.videoPlayer = videoPlayerView
             updateControls()
         }
     }
@@ -156,20 +155,20 @@ import UIKit
         tapGestureRecognizer.delegate = self
         addGestureRecognizer(tapGestureRecognizer)
         
-        let playerView = ASPVideoPlayerView()
-        videoPlayerView = playerView
-        let controlsView = ASPVideoPlayerControls(videoPlayer: playerView)
-        videoPlayerControls = controlsView
+        videoPlayerView = ASPVideoPlayerView()
+        guard let videoPlayerView = videoPlayerView else { return }
         
-        playerView.translatesAutoresizingMaskIntoConstraints = false
-        controlsView.translatesAutoresizingMaskIntoConstraints = false
+        // Note: the controls closures will be set as part of the instantiation
+        // so there's no need to explicitly call `updateControls`
+        videoPlayerControls = ASPVideoPlayerControls(videoPlayer: videoPlayerView)
+        guard let videoPlayerControls = videoPlayerControls else { return }
         
-        controlsView.backgroundColor = UIColor.black.withAlphaComponent(0.15)
-        
-        updateControls()
-        
-        addSubview(playerView)
-        addSubview(controlsView)
+        videoPlayerView.translatesAutoresizingMaskIntoConstraints = false
+        videoPlayerControls.translatesAutoresizingMaskIntoConstraints = false
+        videoPlayerControls.backgroundColor = UIColor.black.withAlphaComponent(0.15)
+
+        addSubview(videoPlayerView)
+        addSubview(videoPlayerControls)
         
         setupLayout()
     }

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -185,7 +185,7 @@ import UIKit
         constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "H:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
         constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
         
-        addConstraints(constraintsArray)
+        NSLayoutConstraint.activate(constraintsArray)
     }
 }
 

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -9,31 +9,31 @@
 import UIKit
 
 /**
-A video player implementation with basic functionality.
-*/
+ A video player implementation with basic functionality.
+ */
 @IBDesignable open class ASPVideoPlayer: UIView {
-	
-	//MARK: - Read-Only Variables and Constants -
-	
-	open fileprivate(set) var videoPlayerView: ASPVideoPlayerView?
-	
-	//MARK: - Public Variables -
-	
-	/**
-	Sets the controls to use for the player. By default the controls are ASPVideoPlayerControls.
-	*/
-	open var videoPlayerControls: ASPBasicControls? {
-		didSet {
-			videoPlayerControls?.videoPlayer = videoPlayerView
-			updateControls()
-		}
-	}
-	
-	/**
-	The duration of the fade animation.
-	*/
-	open var fadeDuration = 0.3
-	
+    
+    //MARK: - Read-Only Variables and Constants -
+    
+    open fileprivate(set) var videoPlayerView: ASPVideoPlayerView?
+    
+    //MARK: - Public Variables -
+    
+    /**
+     Sets the controls to use for the player. By default the controls are ASPVideoPlayerControls.
+     */
+    open var videoPlayerControls: ASPBasicControls? {
+        didSet {
+            videoPlayerControls?.videoPlayer = videoPlayerView
+            updateControls()
+        }
+    }
+    
+    /**
+     The duration of the fade animation.
+     */
+    open var fadeDuration = 0.3
+    
     /**
      A URL that the player will load. Can be a local or remote URL.
      */
@@ -44,162 +44,162 @@ A video player implementation with basic functionality.
         }
     }
     
-	/**
-	An array of URLs that the player will load. Can be local or remote URLs.
-	*/
-	open var videoURLs: [URL] = [] {
-		didSet {
-			videoPlayerView?.videoURLs = videoURLs
-		}
-	}
-	
-	/**
-	Sets the color of the controls.
-	*/
-	override open var tintColor: UIColor? {
-		didSet {
-			videoPlayerControls?.tintColor = tintColor
-		}
-	}
-	
-	//MARK: - Superclass methods -
-	
-	public override init(frame: CGRect) {
-		super.init(frame: frame)
-		
-		commonInit()
-	}
-	
-	public required init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-		
-		commonInit()
-	}
-	
-	//MARK: - Private methods -
-	
-	@objc internal func toggleControls() {
+    /**
+     An array of URLs that the player will load. Can be local or remote URLs.
+     */
+    open var videoURLs: [URL] = [] {
+        didSet {
+            videoPlayerView?.videoURLs = videoURLs
+        }
+    }
+    
+    /**
+     Sets the color of the controls.
+     */
+    override open var tintColor: UIColor? {
+        didSet {
+            videoPlayerControls?.tintColor = tintColor
+        }
+    }
+    
+    //MARK: - Superclass methods -
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        commonInit()
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        commonInit()
+    }
+    
+    //MARK: - Private methods -
+    
+    @objc internal func toggleControls() {
         guard let controls = videoPlayerControls else { return }
         
-		if controls.alpha > 0 && videoPlayerView?.status == .playing {
-			hideControls()
-		} else {
-			NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
-			showControls()
-			
-			if videoPlayerView?.status == .playing {
-				perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
-			}
-		}
-	}
-	
-	internal func showControls() {
+        if controls.alpha > 0 && videoPlayerView?.status == .playing {
+            hideControls()
+        } else {
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
+            showControls()
+            
+            if videoPlayerView?.status == .playing {
+                perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
+            }
+        }
+    }
+    
+    internal func showControls() {
         UIView.animate(withDuration: fadeDuration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut], animations: {
             self.videoPlayerControls?.alpha = 1.0
         }, completion: nil)
-	}
-	
-	@objc internal func hideControls() {
-        UIView.animate(withDuration: fadeDuration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut], animations: { 
+    }
+    
+    @objc internal func hideControls() {
+        UIView.animate(withDuration: fadeDuration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut], animations: {
             self.videoPlayerControls?.alpha = 0.0
         }, completion: nil)
-	}
-	
-	private func updateControls() {
-		videoPlayerControls?.tintColor = tintColor
-		
+    }
+    
+    private func updateControls() {
+        videoPlayerControls?.tintColor = tintColor
+        
         videoPlayerControls?.newVideo = { [weak self] in
             guard let strongSelf = self else { return }
             
-			if let videoURL = strongSelf.videoPlayerView?.currentVideoURL {
-				if let currentURLIndex = strongSelf.videoURLs.index(of: videoURL) {
-					strongSelf.videoPlayerControls?.nextButtonHidden = currentURLIndex == strongSelf.videoURLs.count - 1
-					strongSelf.videoPlayerControls?.previousButtonHidden = currentURLIndex == 0
-				}
-			}
-		}
+            if let videoURL = strongSelf.videoPlayerView?.currentVideoURL {
+                if let currentURLIndex = strongSelf.videoURLs.index(of: videoURL) {
+                    strongSelf.videoPlayerControls?.nextButtonHidden = currentURLIndex == strongSelf.videoURLs.count - 1
+                    strongSelf.videoPlayerControls?.previousButtonHidden = currentURLIndex == 0
+                }
+            }
+        }
         
         videoPlayerControls?.startedVideo = { [weak self] in
             guard let strongSelf = self else { return }
             
             strongSelf.hideControls()
         }
-		
+        
         videoPlayerControls?.didPressNextButton = { [weak self] in
             guard let strongSelf = self else { return }
             
             strongSelf.videoPlayerView?.playNextVideo()
-		}
-		
+        }
+        
         videoPlayerControls?.didPressPreviousButton = { [weak self] in
             guard let strongSelf = self else { return }
             
             strongSelf.videoPlayerView?.playPreviousVideo()
-		}
-		
-		videoPlayerControls?.interacting = { [weak self] (isInteracting) in
+        }
+        
+        videoPlayerControls?.interacting = { [weak self] (isInteracting) in
             guard let strongSelf = self else { return }
             
-			NSObject.cancelPreviousPerformRequests(withTarget: strongSelf, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
-			if isInteracting == true {
-				strongSelf.showControls()
-			} else {
-				if strongSelf.videoPlayerView?.status == .playing {
-					strongSelf.perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
-				}
-			}
-		}
-	}
-	
-	private func commonInit() {
-		let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(ASPVideoPlayer.toggleControls))
-		tapGestureRecognizer.delegate = self
-		addGestureRecognizer(tapGestureRecognizer)
-		
+            NSObject.cancelPreviousPerformRequests(withTarget: strongSelf, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
+            if isInteracting == true {
+                strongSelf.showControls()
+            } else {
+                if strongSelf.videoPlayerView?.status == .playing {
+                    strongSelf.perform(#selector(ASPVideoPlayer.hideControls), with: nil, afterDelay: 3.0)
+                }
+            }
+        }
+    }
+    
+    private func commonInit() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(ASPVideoPlayer.toggleControls))
+        tapGestureRecognizer.delegate = self
+        addGestureRecognizer(tapGestureRecognizer)
+        
         let playerView = ASPVideoPlayerView()
-		videoPlayerView = playerView
+        videoPlayerView = playerView
         let controlsView = ASPVideoPlayerControls(videoPlayer: playerView)
-		videoPlayerControls = controlsView
-		
-		playerView.translatesAutoresizingMaskIntoConstraints = false
-		controlsView.translatesAutoresizingMaskIntoConstraints = false
-		
-		controlsView.backgroundColor = UIColor.black.withAlphaComponent(0.15)
-		
-		updateControls()
-		
-		addSubview(playerView)
-		addSubview(controlsView)
-		
-		setupLayout()
-	}
-	
-	private func setupLayout() {
+        videoPlayerControls = controlsView
+        
+        playerView.translatesAutoresizingMaskIntoConstraints = false
+        controlsView.translatesAutoresizingMaskIntoConstraints = false
+        
+        controlsView.backgroundColor = UIColor.black.withAlphaComponent(0.15)
+        
+        updateControls()
+        
+        addSubview(playerView)
+        addSubview(controlsView)
+        
+        setupLayout()
+    }
+    
+    private func setupLayout() {
         guard let videoPlayerView = videoPlayerView, let videoPlayerControls = videoPlayerControls else { return }
-		let viewsDictionary: [String: Any] = ["videoPlayerView": videoPlayerView,
-		                                      "videoPlayerControls": videoPlayerControls]
-		
-		var constraintsArray = [NSLayoutConstraint]()
-		
-		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "H:|[videoPlayerView]|", options: [], metrics: nil, views: viewsDictionary))
-		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:|[videoPlayerView]|", options: [], metrics: nil, views: viewsDictionary))
-		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "H:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
-		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
-		
-		addConstraints(constraintsArray)
-	}
+        let viewsDictionary: [String: Any] = ["videoPlayerView": videoPlayerView,
+                                              "videoPlayerControls": videoPlayerControls]
+        
+        var constraintsArray = [NSLayoutConstraint]()
+        
+        constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "H:|[videoPlayerView]|", options: [], metrics: nil, views: viewsDictionary))
+        constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:|[videoPlayerView]|", options: [], metrics: nil, views: viewsDictionary))
+        constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "H:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
+        constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:|[videoPlayerControls]|", options: [], metrics: nil, views: viewsDictionary))
+        
+        addConstraints(constraintsArray)
+    }
 }
 
 extension ASPVideoPlayer: UIGestureRecognizerDelegate {
     
-	public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         guard let videoPlayerControls = videoPlayerControls else { return true }
         
-		if let view = touch.view, view.isDescendant(of: self) == true, view != videoPlayerView, view != videoPlayerControls || touch.location(in: videoPlayerControls).y > videoPlayerControls.bounds.size.height - 50 {
-			return false
-		} else {
-			return true
-		}
-	}
+        if let view = touch.view, view.isDescendant(of: self) == true, view != videoPlayerView, view != videoPlayerControls || touch.location(in: videoPlayerControls).y > videoPlayerControls.bounds.size.height - 50 {
+            return false
+        } else {
+            return true
+        }
+    }
     
 }

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -78,7 +78,7 @@ A video player implementation with basic functionality.
 	//MARK: - Private methods -
 	
 	@objc internal func toggleControls() {
-		if videoPlayerControls.alpha == 1.0 && videoPlayerView.status == .playing {
+		if videoPlayerControls.alpha > 0 && videoPlayerView.status == .playing {
 			hideControls()
 		} else {
 			NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ASPVideoPlayer.hideControls), object: nil)
@@ -91,15 +91,15 @@ A video player implementation with basic functionality.
 	}
 	
 	internal func showControls() {
-		UIView.animate(withDuration: fadeDuration, animations: {
-			self.videoPlayerControls.alpha = 1.0
-		})
+        UIView.animate(withDuration: fadeDuration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut], animations: {
+            self.videoPlayerControls.alpha = 1.0
+        }, completion: nil)
 	}
 	
 	@objc internal func hideControls() {
-		UIView.animate(withDuration: fadeDuration, animations: {
-			self.videoPlayerControls.alpha = 0.0
-		})
+        UIView.animate(withDuration: fadeDuration, delay: 0, options: [.beginFromCurrentState, .curveEaseInOut], animations: { 
+            self.videoPlayerControls.alpha = 0.0
+        }, completion: nil)
 	}
 	
 	private func updateControls() {
@@ -115,6 +115,12 @@ A video player implementation with basic functionality.
 				}
 			}
 		}
+        
+        videoPlayerControls.startedVideo = { [weak self] in
+            guard let strongSelf = self else { return }
+            
+            strongSelf.hideControls()
+        }
 		
         videoPlayerControls.finishedVideo = { [weak self] in
             guard let strongSelf = self else { return }

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -29,6 +29,15 @@ import UIKit
     }
     
     /**
+     Whether or not the controls should be hidden until the player is started / interacted with.
+     */
+    open var controlsInitiallyHidden = false {
+        didSet {
+            videoPlayerControls?.alpha = controlsInitiallyHidden ? 0 : 1
+        }
+    }
+    
+    /**
      The duration of the fade animation.
      */
     open var fadeDuration = 0.3

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -13,9 +13,9 @@ A video player implementation with basic functionality.
 */
 @IBDesignable open class ASPVideoPlayer: UIView {
 	
-	//MARK: - Private Variables and Constants -
+	//MARK: - Read-Only Variables and Constants -
 	
-	fileprivate var videoPlayerView: ASPVideoPlayerView!
+	open fileprivate(set) var videoPlayerView: ASPVideoPlayerView!
 	
 	//MARK: - Public Variables -
 	
@@ -40,30 +40,6 @@ A video player implementation with basic functionality.
 	open var videoURLs: [URL] = [] {
 		didSet {
 			videoPlayerView.videoURL = videoURLs.first
-		}
-	}
-	
-	/**
-	The gravity of the video. Adjusts how the video fills the space of the container.
-	*/
-	open var gravity: ASPVideoPlayerView.PlayerContentMode {
-		set {
-			videoPlayerView.gravity = newValue
-		}
-		get {
-			return videoPlayerView.gravity
-		}
-	}
-	
-	/**
-	Sets wether the playlist should loop. Once the last video has finished playing, the first one will start.
-	*/
-	open var shouldLoop: Bool {
-		set {
-			videoPlayerView.shouldLoop = newValue
-		}
-		get {
-			return videoPlayerView.shouldLoop
 		}
 	}
 	

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -48,7 +48,7 @@ A video player implementation with basic functionality.
 	*/
 	open var videoURLs: [URL] = [] {
 		didSet {
-			videoPlayerView.videoURL = videoURLs.first
+			videoPlayerView.videoURLs = videoURLs
 		}
 	}
 	
@@ -108,7 +108,7 @@ A video player implementation with basic functionality.
         videoPlayerControls.newVideo = { [weak self] in
             guard let strongSelf = self else { return }
             
-			if let videoURL = strongSelf.videoPlayerView.videoURL {
+			if let videoURL = strongSelf.videoPlayerView.currentVideoURL {
 				if let currentURLIndex = strongSelf.videoURLs.index(of: videoURL) {
 					strongSelf.videoPlayerControls.nextButtonHidden = currentURLIndex == strongSelf.videoURLs.count - 1
 					strongSelf.videoPlayerControls.previousButtonHidden = currentURLIndex == 0
@@ -122,45 +122,16 @@ A video player implementation with basic functionality.
             strongSelf.hideControls()
         }
 		
-        videoPlayerControls.finishedVideo = { [weak self] in
-            guard let strongSelf = self else { return }
-            
-			if let videoURL = strongSelf.videoPlayerView.videoURL {
-				if videoURL == strongSelf.videoURLs.last {
-					if strongSelf.videoPlayerView.shouldLoop == true {
-						strongSelf.videoPlayerView.videoURL = strongSelf.videoURLs.first
-					}
-				} else {
-					let currentURLIndex = strongSelf.videoURLs.index(of: videoURL)
-					let nextURL = strongSelf.videoURLs[currentURLIndex! + 1]
-					
-					strongSelf.videoPlayerView.videoURL = nextURL
-				}
-			}
-		}
-		
         videoPlayerControls.didPressNextButton = { [weak self] in
             guard let strongSelf = self else { return }
             
-			if let videoURL = strongSelf.videoPlayerView.videoURL {
-				if let currentURLIndex = strongSelf.videoURLs.index(of: videoURL), currentURLIndex + 1 < strongSelf.videoURLs.count {
-					let nextURL = strongSelf.videoURLs[currentURLIndex + 1]
-					
-					strongSelf.videoPlayerView.videoURL = nextURL
-				}
-			}
+            strongSelf.videoPlayerView.playNextVideo()
 		}
 		
         videoPlayerControls.didPressPreviousButton = { [weak self] in
             guard let strongSelf = self else { return }
             
-			if let videoURL = strongSelf.videoPlayerView.videoURL {
-				if let currentURLIndex = strongSelf.videoURLs.index(of: videoURL), currentURLIndex > 0 {
-					let nextURL = strongSelf.videoURLs[currentURLIndex - 1]
-					
-					strongSelf.videoPlayerView.videoURL = nextURL
-				}
-			}
+            strongSelf.videoPlayerView.playPreviousVideo()
 		}
 		
 		videoPlayerControls.interacting = { [weak self] (isInteracting) in

--- a/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayer.swift
@@ -34,6 +34,15 @@ A video player implementation with basic functionality.
 	*/
 	open var fadeDuration = 0.3
 	
+    /**
+     A URL that the player will load. Can be a local or remote URL.
+     */
+    open var videoURL: URL! {
+        didSet {
+            videoURLs = [videoURL]
+        }
+    }
+    
 	/**
 	An array of URLs that the player will load. Can be local or remote URLs.
 	*/

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -528,7 +528,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:[currentTimeLabel(==40)]-3-|", options: [], metrics: nil, views: viewsDictionary))
 		constraintsArray.append(contentsOf: NSLayoutConstraint.constraints(withVisualFormat: "V:[lengthLabel(==40)]-3-|", options: [], metrics: nil, views: viewsDictionary))
 		
-		addConstraints(constraintsArray)
+		NSLayoutConstraint.activate(constraintsArray)
 	}
 	
 	//MARK: - Closure notifications -

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -414,7 +414,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 		playPauseButton.addTarget(self, action: #selector(ASPVideoPlayerControls.playButtonPressed), for: .touchUpInside)
 		nextButton.addTarget(self, action: #selector(ASPVideoPlayerControls.nextButtonPressed), for: .touchUpInside)
 		previousButton.addTarget(self, action: #selector(ASPVideoPlayerControls.previousButtonPressed), for: .touchUpInside)
-		progressSlider.addTarget(self, action: #selector(ASPVideoPlayerControls.progressSliderChanged(slider:)), for: [.touchUpInside])
+		progressSlider.addTarget(self, action: #selector(ASPVideoPlayerControls.progressSliderChanged(slider:)), for: [.valueChanged])
 		progressSlider.addTarget(self, action: #selector(ASPVideoPlayerControls.progressSliderBeginTouch), for: [.touchDown])
 		
 		addSubview(progressLoader)

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -175,7 +175,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	/**
 	Sets the color of the controls.
 	*/
-	open override var tintColor: UIColor! {
+	open override var tintColor: UIColor? {
 		didSet {
 			playPauseButton.tintColor = tintColor
 			nextButton.tintColor = tintColor

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -130,6 +130,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	
 	open var interacting: ((Bool) -> Void)?
 	open var newVideo: (() -> Void)?
+    open var startedVideo: (() -> Void)?
 	open var finishedVideo: (() -> Void)?
 	
 	open var nextButtonHidden: Bool = true
@@ -322,7 +323,10 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
             videoPlayerView.startedVideo = { [weak self] in
                 guard let strongSelf = self else { return }
                 
+                strongSelf.startedVideo?()
+                
 				strongSelf.progressSlider.isUserInteractionEnabled = true
+                strongSelf.playPauseButton.isSelected = true
 				
 				let currentTime = videoPlayerView.currentTime
 				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -317,6 +317,18 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
 			}
 			
+            videoPlayerView.bufferingVideo = { [weak self] in
+                guard let strongSelf = self else { return }
+                
+                strongSelf.progressLoader.startAnimating()
+            }
+            
+            videoPlayerView.bufferingVideoFinished = { [weak self] in
+                guard let strongSelf = self else { return }
+                
+                strongSelf.progressLoader.stopAnimating()
+            }
+            
             videoPlayerView.startedVideo = { [weak self] in
                 guard let strongSelf = self else { return }
                 

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -16,6 +16,11 @@ public protocol VideoPlayerControls {
 	Reference to the video player.
 	*/
 	weak var videoPlayer: ASPVideoPlayerView? {get set}
+    
+    /**
+     The font for the time labels.
+     */
+    var timeFont: UIFont? {get set}
 	
 	/**
 	Starts the video playback.
@@ -129,6 +134,8 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	
 	open var nextButtonHidden: Bool = true
 	open var previousButtonHidden: Bool = true
+    
+    open var timeFont = UIFont(name: "Courier-Bold", size: 12.0)
 }
 
 @IBDesignable open class ASPVideoPlayerControls: ASPBasicControls {
@@ -180,6 +187,16 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 			currentTimeLabel.textColor = tintColor
 		}
 	}
+    
+    /**
+     The font for the time labels.
+     */
+    open override var timeFont: UIFont? {
+        didSet {
+            currentTimeLabel.font = timeFont
+            lengthLabel.font = timeFont
+        }
+    }
 	
 	//MARK: - Private Variables and Constants -
 	
@@ -377,11 +394,11 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 		
 		currentTimeLabel.textColor = tintColor
 		currentTimeLabel.textAlignment = .center
-		currentTimeLabel.font = UIFont(name: "Courier-Bold", size: 12.0)
+		currentTimeLabel.font = timeFont
 		
 		lengthLabel.textColor = tintColor
 		lengthLabel.textAlignment = .center
-		lengthLabel.font = UIFont(name: "Courier-Bold", size: 12.0)
+		lengthLabel.font = timeFont
 		
 		playPauseButton.addTarget(self, action: #selector(ASPVideoPlayerControls.playButtonPressed), for: .touchUpInside)
 		nextButton.addTarget(self, action: #selector(ASPVideoPlayerControls.nextButtonPressed), for: .touchUpInside)

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -131,7 +131,6 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	open var interacting: ((Bool) -> Void)?
 	open var newVideo: (() -> Void)?
     open var startedVideo: (() -> Void)?
-	open var finishedVideo: (() -> Void)?
 	
 	open var nextButtonHidden: Bool = true
 	open var previousButtonHidden: Bool = true
@@ -293,8 +292,6 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				
 				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: 0)
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: 0)
-				
-				strongSelf.progressLoader.startAnimating()
 			}
 			
             videoPlayerView.readyToPlayVideo = { [weak self] in
@@ -340,12 +337,6 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
                 
 				strongSelf.playPauseButton.isSelected = false
 				strongSelf.progressSlider.value = 0.0
-			}
-			
-            videoPlayerView.finishedVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
-				strongSelf.finishedVideo?()
 			}
 			
 			videoPlayerView.error = { (error) in

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -280,7 +280,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	
 	private func setupVideoPlayerView() {
 		if let videoPlayerView = videoPlayer {
-			videoPlayerView.newVideo = { [weak self] in
+			videoPlayerView.newVideo = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.newVideo?()
@@ -294,74 +294,74 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: 0)
 			}
 			
-			videoPlayerView.readyToPlayVideo = { [weak self] in
-				guard let strongSelf = self else { return }
+			videoPlayerView.readyToPlayVideo = { [weak self, weak videoPlayerView] in
+				guard let strongSelf = self, let strongVideoPlayerView = videoPlayerView else { return }
 				
 				strongSelf.progressSlider.isUserInteractionEnabled = true
 				
-				let currentTime = videoPlayerView.currentTime
-				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
+				let currentTime = strongVideoPlayerView.currentTime
+				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(strongVideoPlayerView.videoLength))
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
 				
 				strongSelf.progressLoader.stopAnimating()
 			}
 			
-			videoPlayerView.playingVideo = { [weak self] (progress) in
-				guard let strongSelf = self else { return }
+			videoPlayerView.playingVideo = { [weak self, weak videoPlayerView] (progress) in
+				guard let strongSelf = self, let strongVideoPlayerView = videoPlayerView else { return }
 				
 				if strongSelf.isInteracting == false {
 					strongSelf.progressSlider.value = CGFloat(progress)
 				}
 				
-				let currentTime = videoPlayerView.currentTime
+				let currentTime = strongVideoPlayerView.currentTime
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
 			}
 			
-			videoPlayerView.bufferingVideo = { [weak self] in
+			videoPlayerView.bufferingVideo = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.progressLoader.startAnimating()
 			}
 			
-			videoPlayerView.bufferingVideoFinished = { [weak self] in
+			videoPlayerView.bufferingVideoFinished = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.progressLoader.stopAnimating()
 			}
 			
-			videoPlayerView.startedVideo = { [weak self] in
-				guard let strongSelf = self else { return }
+			videoPlayerView.startedVideo = { [weak self, weak videoPlayerView] in
+				guard let strongSelf = self, let strongVideoPlayerView = videoPlayerView else { return }
 				
 				strongSelf.startedVideo?()
 				
 				strongSelf.progressSlider.isUserInteractionEnabled = true
 				strongSelf.playPauseButton.isSelected = true
 				
-				let currentTime = videoPlayerView.currentTime
-				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
+				let currentTime = strongVideoPlayerView.currentTime
+				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(strongVideoPlayerView.videoLength))
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
 				
 				strongSelf.progressLoader.stopAnimating()
 			}
 			
-			videoPlayerView.stoppedVideo = { [weak self] in
+			videoPlayerView.stoppedVideo = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.playPauseButton.isSelected = false
 				strongSelf.progressSlider.value = 0.0
 			}
 			
-			videoPlayerView.error = { (error) in
+			videoPlayerView.error = { [weak self, weak videoPlayerView] (error) in
 				print(error)
 			}
 			
-			videoPlayerView.seekStarted = { [weak self] in
+			videoPlayerView.seekStarted = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.progressLoader.startAnimating()
 			}
 			
-			videoPlayerView.seekEnded = { [weak self] in
+			videoPlayerView.seekEnded = { [weak self, weak videoPlayerView] in
 				guard let strongSelf = self else { return }
 				
 				strongSelf.progressLoader.stopAnimating()

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -315,6 +315,7 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				
 				let currentTime = strongVideoPlayerView.currentTime
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
+                strongSelf.progressLoader.stopAnimating()
 			}
 			
 			videoPlayerView.bufferingVideo = { [weak self, weak videoPlayerView] in
@@ -349,9 +350,13 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				
 				strongSelf.playPauseButton.isSelected = false
 				strongSelf.progressSlider.value = 0.0
+                strongSelf.progressLoader.stopAnimating()
 			}
 			
 			videoPlayerView.error = { [weak self, weak videoPlayerView] (error) in
+                guard let strongSelf = self else { return }
+                
+                strongSelf.progressLoader.stopAnimating()
 				print(error)
 			}
 			

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -367,7 +367,11 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 		let minutes = (totalSeconds / 60) % 60
 		let hours = totalSeconds / 3600
 		
-		return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        if hours != 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
 	}
 	
 	private func commonInit() {

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerControls.swift
@@ -16,11 +16,11 @@ public protocol VideoPlayerControls {
 	Reference to the video player.
 	*/
 	weak var videoPlayer: ASPVideoPlayerView? {get set}
-    
-    /**
-     The font for the time labels.
-     */
-    var timeFont: UIFont? {get set}
+	
+	/**
+	The font for the time labels.
+	*/
+	var timeFont: UIFont? {get set}
 	
 	/**
 	Starts the video playback.
@@ -130,12 +130,12 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	
 	open var interacting: ((Bool) -> Void)?
 	open var newVideo: (() -> Void)?
-    open var startedVideo: (() -> Void)?
+	open var startedVideo: (() -> Void)?
 	
 	open var nextButtonHidden: Bool = true
 	open var previousButtonHidden: Bool = true
-    
-    open var timeFont = UIFont(name: "Courier-Bold", size: 12.0)
+	
+	open var timeFont = UIFont(name: "Courier-Bold", size: 12.0)
 }
 
 @IBDesignable open class ASPVideoPlayerControls: ASPBasicControls {
@@ -187,16 +187,16 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 			currentTimeLabel.textColor = tintColor
 		}
 	}
-    
-    /**
-     The font for the time labels.
-     */
-    open override var timeFont: UIFont? {
-        didSet {
-            currentTimeLabel.font = timeFont
-            lengthLabel.font = timeFont
-        }
-    }
+	
+	/**
+	The font for the time labels.
+	*/
+	open override var timeFont: UIFont? {
+		didSet {
+			currentTimeLabel.font = timeFont
+			lengthLabel.font = timeFont
+		}
+	}
 	
 	//MARK: - Private Variables and Constants -
 	
@@ -281,8 +281,8 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 	private func setupVideoPlayerView() {
 		if let videoPlayerView = videoPlayer {
 			videoPlayerView.newVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
+				guard let strongSelf = self else { return }
+				
 				strongSelf.newVideo?()
 				
 				strongSelf.progressSlider.isUserInteractionEnabled = false
@@ -294,9 +294,9 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: 0)
 			}
 			
-            videoPlayerView.readyToPlayVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
+			videoPlayerView.readyToPlayVideo = { [weak self] in
+				guard let strongSelf = self else { return }
+				
 				strongSelf.progressSlider.isUserInteractionEnabled = true
 				
 				let currentTime = videoPlayerView.currentTime
@@ -307,8 +307,8 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 			}
 			
 			videoPlayerView.playingVideo = { [weak self] (progress) in
-                guard let strongSelf = self else { return }
-                
+				guard let strongSelf = self else { return }
+				
 				if strongSelf.isInteracting == false {
 					strongSelf.progressSlider.value = CGFloat(progress)
 				}
@@ -317,25 +317,25 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				strongSelf.currentTimeLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(currentTime))
 			}
 			
-            videoPlayerView.bufferingVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
-                strongSelf.progressLoader.startAnimating()
-            }
-            
-            videoPlayerView.bufferingVideoFinished = { [weak self] in
-                guard let strongSelf = self else { return }
-                
-                strongSelf.progressLoader.stopAnimating()
-            }
-            
-            videoPlayerView.startedVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
-                strongSelf.startedVideo?()
-                
+			videoPlayerView.bufferingVideo = { [weak self] in
+				guard let strongSelf = self else { return }
+				
+				strongSelf.progressLoader.startAnimating()
+			}
+			
+			videoPlayerView.bufferingVideoFinished = { [weak self] in
+				guard let strongSelf = self else { return }
+				
+				strongSelf.progressLoader.stopAnimating()
+			}
+			
+			videoPlayerView.startedVideo = { [weak self] in
+				guard let strongSelf = self else { return }
+				
+				strongSelf.startedVideo?()
+				
 				strongSelf.progressSlider.isUserInteractionEnabled = true
-                strongSelf.playPauseButton.isSelected = true
+				strongSelf.playPauseButton.isSelected = true
 				
 				let currentTime = videoPlayerView.currentTime
 				strongSelf.lengthLabel.text = strongSelf.timeFormatted(totalSeconds: UInt(videoPlayerView.videoLength))
@@ -344,9 +344,9 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				strongSelf.progressLoader.stopAnimating()
 			}
 			
-            videoPlayerView.stoppedVideo = { [weak self] in
-                guard let strongSelf = self else { return }
-                
+			videoPlayerView.stoppedVideo = { [weak self] in
+				guard let strongSelf = self else { return }
+				
 				strongSelf.playPauseButton.isSelected = false
 				strongSelf.progressSlider.value = 0.0
 			}
@@ -355,15 +355,15 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 				print(error)
 			}
 			
-            videoPlayerView.seekStarted = { [weak self] in
-                guard let strongSelf = self else { return }
-                
+			videoPlayerView.seekStarted = { [weak self] in
+				guard let strongSelf = self else { return }
+				
 				strongSelf.progressLoader.startAnimating()
 			}
 			
-            videoPlayerView.seekEnded = { [weak self] in
-                guard let strongSelf = self else { return }
-                
+			videoPlayerView.seekEnded = { [weak self] in
+				guard let strongSelf = self else { return }
+				
 				strongSelf.progressLoader.stopAnimating()
 			}
 		}
@@ -374,11 +374,11 @@ open class ASPBasicControls: UIView, VideoPlayerControls, VideoPlayerSeekControl
 		let minutes = (totalSeconds / 60) % 60
 		let hours = totalSeconds / 3600
 		
-        if hours != 0 {
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
-        }
+		if hours != 0 {
+			return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+		} else {
+			return String(format: "%02d:%02d", minutes, seconds)
+		}
 	}
 	
 	private func commonInit() {

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -421,7 +421,11 @@ import AVFoundation
         return videoItems.index(of: currentItem)
     }
     
-    private let videoPlayerLayer = AVPlayerLayer()
+    private lazy var videoPlayerLayer: AVPlayerLayer = { [unowned self] in
+        let layer = AVPlayerLayer()
+        layer.videoGravity = self.videoGravity
+        return layer
+    }()
     
     private var animationForwarder: AnimationForwarder?
     

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -18,21 +18,21 @@ import AVFoundation
     //MARK: - Type definitions -
     
     /**
-     Basic closure type.
+     Void closure type.
      */
-    public typealias VoidClosure = (() -> Void)?
+    public typealias VoidClosure = () -> ()
     
     /**
      Closure type for recurring actions.
      - Parameter progress: The progress indicator value. Value is in range [0.0, 1.0].
      */
-    public typealias ProgressClosure = ((_ progress: Double) -> Void)?
+    public typealias ProgressClosure = (_ progress: Double) -> ()
     
     /**
      Closure type for error handling.
      - Parameter error: The error that occured.
      */
-    public typealias ErrorClosure = ((_ error: NSError) -> Void)?
+    public typealias ErrorClosure = (_ error: NSError) -> ()
     
     //MARK: - Enumerations -
     
@@ -82,64 +82,184 @@ import AVFoundation
     //MARK: - Closures -
     
     /**
-     A closure that will be called when a new video is loaded.
+     Enqueues a closure that will be called when a new video is loaded.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var newVideo: VoidClosure
+    open var newVideo: VoidClosure? {
+        didSet {
+            guard let closure = newVideo else {
+                newVideoClosures.removeAll()
+                return
+            }
+            newVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when the video is ready to play.
+     Enqueues a closure that will be called when the video is ready to play.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var readyToPlayVideo: VoidClosure
+    open var readyToPlayVideo: VoidClosure? {
+        didSet {
+            guard let closure = readyToPlayVideo else {
+                readyToPlayVideoClosures.removeAll()
+                return
+            }
+            readyToPlayVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a video is started.
+     Enqueues a closure that will be called when a video is started.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var startedVideo: VoidClosure
+    open var startedVideo: VoidClosure? {
+        didSet {
+            guard let closure = startedVideo else {
+                startedVideoClosures.removeAll()
+                return
+            }
+            startedVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called repeatedly while the video is playing.
+     Enqueues a closure that will be called repeatedly while the video is playing.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var playingVideo: ProgressClosure
+    open var playingVideo: ProgressClosure? {
+        didSet {
+            guard let closure = playingVideo else {
+                playingVideoClosures.removeAll()
+                return
+            }
+            playingVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a video is buffering.
+     Enqueues a closure that will be called when a video is buffering.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var bufferingVideo: VoidClosure
+    open var bufferingVideo: VoidClosure? {
+        didSet {
+            guard let closure = bufferingVideo else {
+                bufferingVideoClosures.removeAll()
+                return
+            }
+            bufferingVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a video is finished buffering.
+     Enqueues a closure that will be called when a video is finished buffering.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var bufferingVideoFinished: VoidClosure
+    open var bufferingVideoFinished: VoidClosure? {
+        didSet {
+            guard let closure = bufferingVideoFinished else {
+                bufferingVideoFinishedClosures.removeAll()
+                return
+            }
+            bufferingVideoFinishedClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a video is paused.
+     Enqueues a closure that will be called when a video is paused.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var pausedVideo: VoidClosure
+    open var pausedVideo: VoidClosure? {
+        didSet {
+            guard let closure = pausedVideo else {
+                pausedVideoClosures.removeAll()
+                return
+            }
+            pausedVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when the end of the video has been reached.
+     Enqueues a closure that will be called when the end of the video has been reached.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var finishedVideo: VoidClosure
+    open var finishedVideo: VoidClosure? {
+        didSet {
+            guard let closure = finishedVideo else {
+                finishedVideoClosures.removeAll()
+                return
+            }
+            finishedVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a video is stopped.
+     Enqueues a closure that will be called when a video is stopped.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var stoppedVideo: VoidClosure
+    open var stoppedVideo: VoidClosure? {
+        didSet {
+            guard let closure = stoppedVideo else {
+                stoppedVideoClosures.removeAll()
+                return
+            }
+            stoppedVideoClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a seek is triggered.
+     Enqueues a closure that will be called when a seek is triggered.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var seekStarted: VoidClosure
+    open var seekStarted: VoidClosure? {
+        didSet {
+            guard let closure = seekStarted else {
+                seekStartedClosures.removeAll()
+                return
+            }
+            seekStartedClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when a seek has ended.
+     Enqueues a closure that will be called when a seek has ended.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var seekEnded: VoidClosure
+    open var seekEnded: VoidClosure? {
+        didSet {
+            guard let closure = seekEnded else {
+                seekEndedClosures.removeAll()
+                return
+            }
+            seekEndedClosures.append(closure)
+        }
+    }
     
     /**
-     A closure that will be called when an error occured.
+     Enqueues a closure that will be called when an error occured.
+     
+     Note: a `nil` value will clear all enqueued closures of this type.
      */
-    open var error: ErrorClosure
+    open var error: ErrorClosure? {
+        didSet {
+            guard let closure = error else {
+                errorClosures.removeAll()
+                return
+            }
+            errorClosures.append(closure)
+        }
+    }
     
     //MARK: - Public Variables -
     
@@ -280,6 +400,19 @@ import AVFoundation
     
     //MARK: - Private Variables and Constants -
     
+    private var newVideoClosures = [VoidClosure]()
+    private var readyToPlayVideoClosures = [VoidClosure]()
+    private var startedVideoClosures = [VoidClosure]()
+    private var playingVideoClosures = [ProgressClosure]()
+    private var bufferingVideoClosures = [VoidClosure]()
+    private var bufferingVideoFinishedClosures = [VoidClosure]()
+    private var pausedVideoClosures = [VoidClosure]()
+    private var finishedVideoClosures = [VoidClosure]()
+    private var stoppedVideoClosures = [VoidClosure]()
+    private var seekStartedClosures = [VoidClosure]()
+    private var seekEndedClosures = [VoidClosure]()
+    private var errorClosures = [ErrorClosure]()
+    
     private var videoItems = [AVPlayerItem]()
     
     private var currentVideoIndex: Int? {
@@ -349,7 +482,7 @@ import AVFoundation
         
         status = .playing
         videoPlayerLayer.player?.rate = 1.0
-        startedVideo?()
+        notifyOfStartedVideo()
         
         NotificationCenter.default.removeObserver(self)
         if let currentItem = videoPlayerLayer.player?.currentItem {
@@ -363,7 +496,7 @@ import AVFoundation
     open func pauseVideo() {
         videoPlayerLayer.player?.rate = 0.0
         status = .paused
-        pausedVideo?()
+        notifyOfPausedVideo()
     }
     
     /**
@@ -393,7 +526,7 @@ import AVFoundation
         videoPlayerLayer.player?.rate = 0.0
         seekToZero()
         status = .stopped
-        stoppedVideo?()
+        notifyOfStoppedVideo()
     }
     
     /**
@@ -404,16 +537,16 @@ import AVFoundation
         if let currentItem = videoPlayerLayer.player?.currentItem {
             if progress == 0.0 {
                 seekToZero()
-                playingVideo?(progress)
+                notifyOfPlayingVideo(progress)
             } else {
                 let time = CMTime(seconds: progress * currentItem.asset.duration.seconds, preferredTimescale: currentItem.asset.duration.timescale)
                 videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero, completionHandler: { [weak self] (finished) in
                     guard let strongSelf = self else { return }
                     if finished == false {
-                        strongSelf.seekStarted?()
+                        strongSelf.notifyOfSeekStarted()
                     } else {
-                        strongSelf.seekEnded?()
-                        strongSelf.playingVideo?(strongSelf.progress)
+                        strongSelf.notifyOfSeekEnded()
+                        strongSelf.notifyOfPlayingVideo(strongSelf.progress)
                     }
                 })
             }
@@ -435,9 +568,9 @@ import AVFoundation
         case statusKey:
             handleStatusChange(for: item)
         case playbackBufferEmptyKey:
-            bufferingVideo?()
+            notifyOfBufferingVideo()
         case playbackLikelyToKeepUpKey:
-            bufferingVideoFinished?()
+            notifyOfBufferingVideoFinished()
         default:
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
@@ -469,7 +602,7 @@ import AVFoundation
             if startPlayingWhenReady == true {
                 playVideo()
             } else {
-                readyToPlayVideo?()
+                notifyOfReadyToPlayVideo()
             }
         } else if item.status == .failed {
             generateError(message: "Error loading video.")
@@ -516,7 +649,7 @@ import AVFoundation
         let userInfo = [NSLocalizedDescriptionKey: message]
         let videoError = NSError(domain: "com.andreisergiupitis.aspvideoplayer", code: 99, userInfo: userInfo)
         
-        error?(videoError)
+        notifyOfError(videoError)
     }
     
     fileprivate func seekToZero() {
@@ -536,7 +669,7 @@ import AVFoundation
             let currentTime = time.seconds
             strongSelf.progress = currentTime / (strongSelf.videoLength != 0.0 ? strongSelf.videoLength : 1.0)
             
-            strongSelf.playingVideo?(strongSelf.progress)
+            strongSelf.notifyOfPlayingVideo(strongSelf.progress)
         }) as AnyObject?
     }
     
@@ -560,7 +693,7 @@ import AVFoundation
               notificationItem == currentItem
             else { return }
         
-        finishedVideo?()
+        notifyOfFinishedVideo()
         
         if let lastVideoURL = videoURLs?.last, currentVideoURL != lastVideoURL {
             playNextVideo()
@@ -607,8 +740,55 @@ import AVFoundation
         notifyOfNewVideo()
     }
     
+    //MARK: - Closure notifications -
+    
     fileprivate func notifyOfNewVideo() {
         status = .new
-        newVideo?()
+        newVideoClosures.forEach({ $0() })
     }
+    
+    fileprivate func notifyOfReadyToPlayVideo() {
+        readyToPlayVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfStartedVideo() {
+        startedVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfPlayingVideo(_ progress: Double) {
+        playingVideoClosures.forEach({ $0(progress) })
+    }
+    
+    fileprivate func notifyOfBufferingVideo() {
+        bufferingVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfBufferingVideoFinished() {
+        bufferingVideoFinishedClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfPausedVideo() {
+        pausedVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfFinishedVideo() {
+        finishedVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfStoppedVideo() {
+        stoppedVideoClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfSeekStarted() {
+        seekStartedClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfSeekEnded() {
+        seekEndedClosures.forEach({ $0() })
+    }
+    
+    fileprivate func notifyOfError(_ error: NSError) {
+        errorClosures.forEach({ $0(error) })
+    }
+
 }

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -407,12 +407,13 @@ import AVFoundation
                 playingVideo?(progress)
             } else {
                 let time = CMTime(seconds: progress * currentItem.asset.duration.seconds, preferredTimescale: currentItem.asset.duration.timescale)
-                videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero, completionHandler: { (finished) in
+                videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero, completionHandler: { [weak self] (finished) in
+                    guard let strongSelf = self else { return }
                     if finished == false {
-                        self.seekStarted?()
+                        strongSelf.seekStarted?()
                     } else {
-                        self.seekEnded?()
-                        self.playingVideo?(self.progress)
+                        strongSelf.seekEnded?()
+                        strongSelf.playingVideo?(strongSelf.progress)
                     }
                 })
             }
@@ -530,12 +531,12 @@ import AVFoundation
         }
         
         timeObserver = videoPlayerLayer.player?.addPeriodicTimeObserver(forInterval: CMTime(seconds: 0.01, preferredTimescale: Int32(NSEC_PER_SEC)), queue: nil, using: { [weak self] (time) in
-            guard let weakSelf = self , self?.status == .playing else { return }
+            guard let strongSelf = self , strongSelf.status == .playing else { return }
             
             let currentTime = time.seconds
-            weakSelf.progress = currentTime / (weakSelf.videoLength != 0.0 ? weakSelf.videoLength : 1.0)
+            strongSelf.progress = currentTime / (strongSelf.videoLength != 0.0 ? strongSelf.videoLength : 1.0)
             
-            weakSelf.playingVideo?(weakSelf.progress)
+            strongSelf.playingVideo?(strongSelf.progress)
         }) as AnyObject?
     }
     

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -146,7 +146,11 @@ A simple UIView subclass that can play a video and allows animations to be appli
 	/**
 	Sets whether the video should loop.
 	*/
-	open var shouldLoop: Bool = false
+    open var shouldLoop: Bool = false {
+        didSet {
+            videoPlayerLayer.player?.actionAtItemEnd = shouldLoop ? .none : .pause
+        }
+    }
 	
 	/**
 	Sets whether the video should start automatically after it has been successfuly loaded.

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -288,11 +288,11 @@ A simple UIView subclass that can play a video and allows animations to be appli
         return videoItems.index(of: currentItem)
     }
 	
-	private let videoPlayerLayer: AVPlayerLayer = AVPlayerLayer()
+	private let videoPlayerLayer = AVPlayerLayer()
 	
-	private var animationForwarder: AnimationForwarder!
+	private var animationForwarder: AnimationForwarder?
 	
-	private var videoGravity: String! = AVLayerVideoGravityResizeAspectFill
+	private var videoGravity = AVLayerVideoGravityResizeAspectFill
 	
 	private var timeObserver: AnyObject?
     
@@ -324,7 +324,7 @@ A simple UIView subclass that can play a video and allows animations to be appli
 	open override func layoutSubviews() {
 		super.layoutSubviews()
 		
-		if layer.sublayers == nil || !layer.sublayers!.contains(videoPlayerLayer) {
+		if layer.sublayers == nil || layer.sublayers?.contains(videoPlayerLayer) == false {
 			layer.addSublayer(videoPlayerLayer)
 			animationForwarder = AnimationForwarder(view: self)
 			videoPlayerLayer.delegate = animationForwarder
@@ -456,6 +456,8 @@ A simple UIView subclass that can play a video and allows animations to be appli
     }
     
     fileprivate func handleStatusChange(for item: AVPlayerItem) {
+        guard let currentItem = videoPlayerLayer.player?.currentItem, currentItem == item else { return }
+        
         if item.status == .readyToPlay {
             if status == .new {
                 status = .readyToPlay

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -130,12 +130,12 @@ A simple UIView subclass that can play a video and allows animations to be appli
 	//MARK: - Public Variables -
 	
 	/**
-	Sets wether the video should loop.
+	Sets whether the video should loop.
 	*/
 	open var shouldLoop: Bool = false
 	
 	/**
-	Sets wether the video should start automatically after it has been successfuly loaded.
+	Sets whether the video should start automatically after it has been successfuly loaded.
 	*/
 	open var startPlayingWhenReady: Bool = false
 	

--- a/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
+++ b/ASPVideoPlayer/Classes/ASPVideoPlayerView.swift
@@ -11,159 +11,159 @@ import AVKit
 import AVFoundation
 
 /**
-A simple UIView subclass that can play a video and allows animations to be applied during playback.
-*/
+ A simple UIView subclass that can play a video and allows animations to be applied during playback.
+ */
 @IBDesignable open class ASPVideoPlayerView: UIView {
-	
-	//MARK: - Type definitions -
-	
-	/**
-	Basic closure type.
-	*/
-	public typealias VoidClosure = (() -> Void)?
-	
-	/**
-	Closure type for recurring actions.
-	- Parameter progress: The progress indicator value. Value is in range [0.0, 1.0].
-	*/
-	public typealias ProgressClosure = ((_ progress: Double) -> Void)?
-	
-	/**
-	Closure type for error handling.
-	- Parameter error: The error that occured.
-	*/
-	public typealias ErrorClosure = ((_ error: NSError) -> Void)?
-	
-	//MARK: - Enumerations -
-	
-	/**
-	Specifies how the video is displayed within a player layer’s bounds.
-	*/
-	public enum PlayerContentMode {
-		case aspectFill
-		case aspectFit
-		case resize
-	}
-	
-	/**
-	Specifies the current status of the player.
-	*/
-	public enum PlayerStatus {
-		/**
-		A new video has been assigned.
-		*/
-		case new
-		/**
-		The video is ready to be played.
-		*/
-		case readyToPlay
-		/**
-		The video is currently being played.
-		*/
-		case playing
-        /**
-        The video is buffering.
-        */
-        case buffering
-		/**
-		The video has been paused.
-		*/
-		case paused
-		/**
-		The video playback has been stopped.
-		*/
-		case stopped
-		/**
-		An error occured. For more details use the `error` closure.
-		*/
-		case error
-	}
-	
-	//MARK: - Closures -
-	
-	/**
-	A closure that will be called when a new video is loaded.
-	*/
-	open var newVideo: VoidClosure
-	
-	/**
-	A closure that will be called when the video is ready to play.
-	*/
-	open var readyToPlayVideo: VoidClosure
-	
-	/**
-	A closure that will be called when a video is started.
-	*/
-	open var startedVideo: VoidClosure
-	
-	/**
-	A closure that will be called repeatedly while the video is playing.
-	*/
-	open var playingVideo: ProgressClosure
+    
+    //MARK: - Type definitions -
     
     /**
-    A closure that will be called when a video is buffering.
+     Basic closure type.
+     */
+    public typealias VoidClosure = (() -> Void)?
+    
+    /**
+     Closure type for recurring actions.
+     - Parameter progress: The progress indicator value. Value is in range [0.0, 1.0].
+     */
+    public typealias ProgressClosure = ((_ progress: Double) -> Void)?
+    
+    /**
+     Closure type for error handling.
+     - Parameter error: The error that occured.
+     */
+    public typealias ErrorClosure = ((_ error: NSError) -> Void)?
+    
+    //MARK: - Enumerations -
+    
+    /**
+     Specifies how the video is displayed within a player layer’s bounds.
+     */
+    public enum PlayerContentMode {
+        case aspectFill
+        case aspectFit
+        case resize
+    }
+    
+    /**
+     Specifies the current status of the player.
+     */
+    public enum PlayerStatus {
+        /**
+         A new video has been assigned.
+         */
+        case new
+        /**
+         The video is ready to be played.
+         */
+        case readyToPlay
+        /**
+         The video is currently being played.
+         */
+        case playing
+        /**
+         The video is buffering.
+         */
+        case buffering
+        /**
+         The video has been paused.
+         */
+        case paused
+        /**
+         The video playback has been stopped.
+         */
+        case stopped
+        /**
+         An error occured. For more details use the `error` closure.
+         */
+        case error
+    }
+    
+    //MARK: - Closures -
+    
+    /**
+     A closure that will be called when a new video is loaded.
+     */
+    open var newVideo: VoidClosure
+    
+    /**
+     A closure that will be called when the video is ready to play.
+     */
+    open var readyToPlayVideo: VoidClosure
+    
+    /**
+     A closure that will be called when a video is started.
+     */
+    open var startedVideo: VoidClosure
+    
+    /**
+     A closure that will be called repeatedly while the video is playing.
+     */
+    open var playingVideo: ProgressClosure
+    
+    /**
+     A closure that will be called when a video is buffering.
      */
     open var bufferingVideo: VoidClosure
     
     /**
-    A closure that will be called when a video is finished buffering.
+     A closure that will be called when a video is finished buffering.
      */
     open var bufferingVideoFinished: VoidClosure
-	
-	/**
-	A closure that will be called when a video is paused.
-	*/
-	open var pausedVideo: VoidClosure
-	
-	/**
-	A closure that will be called when the end of the video has been reached.
-	*/
-	open var finishedVideo: VoidClosure
-	
-	/**
-	A closure that will be called when a video is stopped.
-	*/
-	open var stoppedVideo: VoidClosure
-	
-	/**
-	A closure that will be called when a seek is triggered.
-	*/
-	open var seekStarted: VoidClosure
-	
-	/**
-	A closure that will be called when a seek has ended.
-	*/
-	open var seekEnded: VoidClosure
-	
-	/**
-	A closure that will be called when an error occured.
-	*/
-	open var error: ErrorClosure
-	
-	//MARK: - Public Variables -
-	
-	/**
-	Sets whether the video should loop.
-	*/
+    
+    /**
+     A closure that will be called when a video is paused.
+     */
+    open var pausedVideo: VoidClosure
+    
+    /**
+     A closure that will be called when the end of the video has been reached.
+     */
+    open var finishedVideo: VoidClosure
+    
+    /**
+     A closure that will be called when a video is stopped.
+     */
+    open var stoppedVideo: VoidClosure
+    
+    /**
+     A closure that will be called when a seek is triggered.
+     */
+    open var seekStarted: VoidClosure
+    
+    /**
+     A closure that will be called when a seek has ended.
+     */
+    open var seekEnded: VoidClosure
+    
+    /**
+     A closure that will be called when an error occured.
+     */
+    open var error: ErrorClosure
+    
+    //MARK: - Public Variables -
+    
+    /**
+     Sets whether the video should loop.
+     */
     open var shouldLoop: Bool = false {
         didSet {
             videoPlayerLayer.player?.actionAtItemEnd = shouldLoop ? .none : .pause
         }
     }
-	
-	/**
-	Sets whether the video should start automatically after it has been successfuly loaded.
-	*/
-	open var startPlayingWhenReady: Bool = false
-	
-	/**
-	The current status of the video player.
-	*/
-	open fileprivate(set) var status: PlayerStatus = .new
-	
+    
     /**
-    The url of the currently playing video.
+     Sets whether the video should start automatically after it has been successfuly loaded.
+     */
+    open var startPlayingWhenReady: Bool = false
+    
+    /**
+     The current status of the video player.
+     */
+    open fileprivate(set) var status: PlayerStatus = .new
+    
+    /**
+     The url of the currently playing video.
      */
     open var currentVideoURL: URL? {
         guard let urlAsset = videoPlayerLayer.player?.currentItem?.asset as? AVURLAsset else { return nil }
@@ -171,22 +171,22 @@ A simple UIView subclass that can play a video and allows animations to be appli
         return urlAsset.url
     }
     
-	/**
-	The url of the video that should be loaded.
-	*/
-	open var videoURL: URL? = nil {
-		didSet {
+    /**
+     The url of the video that should be loaded.
+     */
+    open var videoURL: URL? = nil {
+        didSet {
             guard let url = videoURL else {
                 generateError(message: "Video URL is invalid (can't be nil).")
                 return
             }
             
             videoURLs = [url]
-		}
-	}
+        }
+    }
     
     /**
-    The urls of the videos that should be loaded.
+     The urls of the videos that should be loaded.
      */
     open var videoURLs: [URL]? = nil {
         didSet {
@@ -222,63 +222,63 @@ A simple UIView subclass that can play a video and allows animations to be appli
             }
         }
     }
-	
-	/**
-	The gravity of the video. Adjusts how the video fills the space of the container.
-	*/
-	open var gravity: PlayerContentMode = .aspectFill {
-		didSet {
-			switch gravity {
-			case .aspectFill:
-				videoGravity = AVLayerVideoGravityResizeAspectFill
-			case .aspectFit:
-				videoGravity = AVLayerVideoGravityResizeAspect
-			case .resize:
-				videoGravity = AVLayerVideoGravityResize
-			}
-			
-			videoPlayerLayer.videoGravity = videoGravity
-		}
-	}
-	
-	/**
-	The volume of the player. Should be a value in the range [0.0, 1.0].
-	*/
-	open var volume: Float {
-		set {
-			let value = min(1.0, max(0.0, newValue))
-			videoPlayerLayer.player?.volume = value
-		}
-		get {
-			return videoPlayerLayer.player?.volume ?? 0.0
-		}
-	}
-	
-	/**
-	The current playback time in seconds.
-	*/
-	open var currentTime: Double {
-		if let time = videoPlayerLayer.player?.currentItem?.currentTime() {
-			return time.seconds
-		}
-		
-		return 0.0
-	}
-	
-	/**
-	The length of the video in seconds.
-	*/
-	open var videoLength: Double {
-		if let duration = videoPlayerLayer.player?.currentItem?.asset.duration {
-			return duration.seconds
-		}
-		
-		return 0.0
-	}
-	
-	fileprivate(set) var progress: Double = 0.0
-	
-	//MARK: - Private Variables and Constants -
+    
+    /**
+     The gravity of the video. Adjusts how the video fills the space of the container.
+     */
+    open var gravity: PlayerContentMode = .aspectFill {
+        didSet {
+            switch gravity {
+            case .aspectFill:
+                videoGravity = AVLayerVideoGravityResizeAspectFill
+            case .aspectFit:
+                videoGravity = AVLayerVideoGravityResizeAspect
+            case .resize:
+                videoGravity = AVLayerVideoGravityResize
+            }
+            
+            videoPlayerLayer.videoGravity = videoGravity
+        }
+    }
+    
+    /**
+     The volume of the player. Should be a value in the range [0.0, 1.0].
+     */
+    open var volume: Float {
+        set {
+            let value = min(1.0, max(0.0, newValue))
+            videoPlayerLayer.player?.volume = value
+        }
+        get {
+            return videoPlayerLayer.player?.volume ?? 0.0
+        }
+    }
+    
+    /**
+     The current playback time in seconds.
+     */
+    open var currentTime: Double {
+        if let time = videoPlayerLayer.player?.currentItem?.currentTime() {
+            return time.seconds
+        }
+        
+        return 0.0
+    }
+    
+    /**
+     The length of the video in seconds.
+     */
+    open var videoLength: Double {
+        if let duration = videoPlayerLayer.player?.currentItem?.asset.duration {
+            return duration.seconds
+        }
+        
+        return 0.0
+    }
+    
+    fileprivate(set) var progress: Double = 0.0
+    
+    //MARK: - Private Variables and Constants -
     
     private var videoItems = [AVPlayerItem]()
     
@@ -287,14 +287,14 @@ A simple UIView subclass that can play a video and allows animations to be appli
         
         return videoItems.index(of: currentItem)
     }
-	
-	private let videoPlayerLayer = AVPlayerLayer()
-	
-	private var animationForwarder: AnimationForwarder?
-	
-	private var videoGravity = AVLayerVideoGravityResizeAspectFill
-	
-	private var timeObserver: AnyObject?
+    
+    private let videoPlayerLayer = AVPlayerLayer()
+    
+    private var animationForwarder: AnimationForwarder?
+    
+    private var videoGravity = AVLayerVideoGravityResizeAspectFill
+    
+    private var timeObserver: AnyObject?
     
     private let statusKey = "status"
     private let playbackBufferEmptyKey = "playbackBufferEmpty"
@@ -304,70 +304,70 @@ A simple UIView subclass that can play a video and allows animations to be appli
     private let assetTracksKey = "tracks"
     private let assetPlayableKey = "playable"
     private let assetDurationKey = "duration"
-	
-	//MARK: - Superclass methods -
-	
-	override init(frame: CGRect) {
-		super.init(frame: frame)
-	}
-	
-	public required init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-	}
-	
-	open override var frame: CGRect {
-		didSet {
-			videoPlayerLayer.frame = bounds
-		}
-	}
-	
-	open override func layoutSubviews() {
-		super.layoutSubviews()
-		
-		if layer.sublayers == nil || layer.sublayers?.contains(videoPlayerLayer) == false {
-			layer.addSublayer(videoPlayerLayer)
-			animationForwarder = AnimationForwarder(view: self)
-			videoPlayerLayer.delegate = animationForwarder
-		}
-		
-		videoPlayerLayer.frame = bounds
-	}
-	
-	deinit {
-		removeObservers()
-	}
-	
-	//MARK: - Public methods -
-	
-	/**
-	Starts the video player from the beginning.
-	*/
-	open func playVideo() {
-		if progress >= 1.0 {
-			seekToZero()
-		}
-		
-		status = .playing
-		videoPlayerLayer.player?.rate = 1.0
-		startedVideo?()
-		
-		NotificationCenter.default.removeObserver(self)
-		if let currentItem = videoPlayerLayer.player?.currentItem {
-            addNotificationObservers(to: currentItem)
-		}
-	}
-	
-	/**
-	Pauses the video.
-	*/
-	open func pauseVideo() {
-		videoPlayerLayer.player?.rate = 0.0
-		status = .paused
-		pausedVideo?()
-	}
+    
+    //MARK: - Superclass methods -
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    open override var frame: CGRect {
+        didSet {
+            videoPlayerLayer.frame = bounds
+        }
+    }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        if layer.sublayers == nil || layer.sublayers?.contains(videoPlayerLayer) == false {
+            layer.addSublayer(videoPlayerLayer)
+            animationForwarder = AnimationForwarder(view: self)
+            videoPlayerLayer.delegate = animationForwarder
+        }
+        
+        videoPlayerLayer.frame = bounds
+    }
+    
+    deinit {
+        removeObservers()
+    }
+    
+    //MARK: - Public methods -
     
     /**
-    Starts the previous video in the queue from the beginning.
+     Starts the video player from the beginning.
+     */
+    open func playVideo() {
+        if progress >= 1.0 {
+            seekToZero()
+        }
+        
+        status = .playing
+        videoPlayerLayer.player?.rate = 1.0
+        startedVideo?()
+        
+        NotificationCenter.default.removeObserver(self)
+        if let currentItem = videoPlayerLayer.player?.currentItem {
+            addNotificationObservers(to: currentItem)
+        }
+    }
+    
+    /**
+     Pauses the video.
+     */
+    open func pauseVideo() {
+        videoPlayerLayer.player?.rate = 0.0
+        status = .paused
+        pausedVideo?()
+    }
+    
+    /**
+     Starts the previous video in the queue from the beginning.
      */
     open func playPreviousVideo() {
         guard let currentVideoIndex = currentVideoIndex else { return }
@@ -377,7 +377,7 @@ A simple UIView subclass that can play a video and allows animations to be appli
     }
     
     /**
-    Starts the next video in the queue from the beginning.
+     Starts the next video in the queue from the beginning.
      */
     open func playNextVideo() {
         guard let currentVideoIndex = currentVideoIndex else { return }
@@ -385,48 +385,49 @@ A simple UIView subclass that can play a video and allows animations to be appli
         let nextVideoIndex = (currentVideoIndex + 1) % videoItems.count
         skipToVideo(at: nextVideoIndex)
     }
-	
-	/**
-	Stops the video.
-	*/
-	open func stopVideo() {
-		videoPlayerLayer.player?.rate = 0.0
-		seekToZero()
-		status = .stopped
-		stoppedVideo?()
-	}
-	
-	/**
-	Seek to specific position in video. Should be a value in the range [0.0, 1.0].
-	*/
-	open func seek(_ percentage: Double) {
-		progress = min(1.0, max(0.0, percentage))
-		if let currentItem = videoPlayerLayer.player?.currentItem {
-			if progress == 0.0 {
-				seekToZero()
-				playingVideo?(progress)
-			} else {
-				let time = CMTime(seconds: progress * currentItem.asset.duration.seconds, preferredTimescale: currentItem.asset.duration.timescale)
-				videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero, completionHandler: { (finished) in
-					if finished == false {
-						self.seekStarted?()
-					} else {
-						self.seekEnded?()
-						self.playingVideo?(self.progress)
-					}
-				})
-			}
-		}
-	}
-	
-	//MARK: - KeyValueObserving methods -
-	
-	open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    
+    /**
+     Stops the video.
+     */
+    open func stopVideo() {
+        videoPlayerLayer.player?.rate = 0.0
+        seekToZero()
+        status = .stopped
+        stoppedVideo?()
+    }
+    
+    /**
+     Seek to specific position in video. Should be a value in the range [0.0, 1.0].
+     */
+    open func seek(_ percentage: Double) {
+        progress = min(1.0, max(0.0, percentage))
+        if let currentItem = videoPlayerLayer.player?.currentItem {
+            if progress == 0.0 {
+                seekToZero()
+                playingVideo?(progress)
+            } else {
+                let time = CMTime(seconds: progress * currentItem.asset.duration.seconds, preferredTimescale: currentItem.asset.duration.timescale)
+                videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero, completionHandler: { (finished) in
+                    if finished == false {
+                        self.seekStarted?()
+                    } else {
+                        self.seekEnded?()
+                        self.playingVideo?(self.progress)
+                    }
+                })
+            }
+        }
+    }
+    
+    //MARK: - KeyValueObserving methods -
+    
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         guard context == &kvoContext,
               let aspKeyPath = keyPath,
-              let item = object as? AVPlayerItem else {
-            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-            return
+              let item = object as? AVPlayerItem
+            else {
+                super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+                return
         }
         
         switch aspKeyPath {
@@ -437,9 +438,9 @@ A simple UIView subclass that can play a video and allows animations to be appli
         case playbackLikelyToKeepUpKey:
             bufferingVideoFinished?()
         default:
-           super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
-	}
+    }
     
     fileprivate func addKVObservers(to item: AVPlayerItem?) {
         guard let item = item else { return }
@@ -473,13 +474,13 @@ A simple UIView subclass that can play a video and allows animations to be appli
             generateError(message: "Error loading video.")
         }
     }
-	
-	//MARK: - Private methods -
+    
+    //MARK: - Private methods -
     
     fileprivate func loadAsset(for url: URL, completion: @escaping ((_ item: AVPlayerItem?) -> Void)) {
         let asset = AVAsset(url: url)
         let keys = [assetTracksKey, assetPlayableKey, assetDurationKey]
-
+        
         asset.loadValuesAsynchronously(forKeys: keys, completionHandler: { [weak self] in
             DispatchQueue.main.sync(execute: {
                 guard let strongSelf = self else {
@@ -516,57 +517,58 @@ A simple UIView subclass that can play a video and allows animations to be appli
         
         error?(videoError)
     }
-	
-	fileprivate func seekToZero() {
-		progress = 0.0
-		let time = CMTime(seconds: 0.0, preferredTimescale: 1)
-		videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
-	}
-	
-	fileprivate func addTimeObserver() {
-		if let observer = timeObserver {
-			videoPlayerLayer.player?.removeTimeObserver(observer)
-		}
-		
-		timeObserver = videoPlayerLayer.player?.addPeriodicTimeObserver(forInterval: CMTime(seconds: 0.01, preferredTimescale: Int32(NSEC_PER_SEC)), queue: nil, using: { [weak self] (time) in
-			guard let weakSelf = self , self?.status == .playing else { return }
-			
-			let currentTime = time.seconds
-			weakSelf.progress = currentTime / (weakSelf.videoLength != 0.0 ? weakSelf.videoLength : 1.0)
-			
-			weakSelf.playingVideo?(weakSelf.progress)
-		}) as AnyObject?
-	}
+    
+    fileprivate func seekToZero() {
+        progress = 0.0
+        let time = CMTime(seconds: 0.0, preferredTimescale: 1)
+        videoPlayerLayer.player?.seek(to: time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
+    }
+    
+    fileprivate func addTimeObserver() {
+        if let observer = timeObserver {
+            videoPlayerLayer.player?.removeTimeObserver(observer)
+        }
+        
+        timeObserver = videoPlayerLayer.player?.addPeriodicTimeObserver(forInterval: CMTime(seconds: 0.01, preferredTimescale: Int32(NSEC_PER_SEC)), queue: nil, using: { [weak self] (time) in
+            guard let weakSelf = self , self?.status == .playing else { return }
+            
+            let currentTime = time.seconds
+            weakSelf.progress = currentTime / (weakSelf.videoLength != 0.0 ? weakSelf.videoLength : 1.0)
+            
+            weakSelf.playingVideo?(weakSelf.progress)
+        }) as AnyObject?
+    }
     
     fileprivate func addNotificationObservers(to item: AVPlayerItem) {
         NotificationCenter.default.addObserver(self, selector: #selector(itemDidFinishPlaying(_:)) , name: .AVPlayerItemDidPlayToEndTime, object: item)
         NotificationCenter.default.addObserver(self, selector: #selector(itemFailedToPlayToEndTime(_:)), name: .AVPlayerItemFailedToPlayToEndTime, object: item)
     }
-	
-	fileprivate func removeObservers() {
-		NotificationCenter.default.removeObserver(self)
-		removeKVObservers()
-		if let observer = timeObserver {
-			videoPlayerLayer.player?.removeTimeObserver(observer)
-			timeObserver = nil
-		}
-	}
-	
+    
+    fileprivate func removeObservers() {
+        NotificationCenter.default.removeObserver(self)
+        removeKVObservers()
+        if let observer = timeObserver {
+            videoPlayerLayer.player?.removeTimeObserver(observer)
+            timeObserver = nil
+        }
+    }
+    
     @objc internal func itemDidFinishPlaying(_ notification: Notification) {
         guard let notificationItem = notification.object as? AVPlayerItem,
               let currentItem = videoPlayerLayer.player?.currentItem,
-              notificationItem == currentItem else { return }
+              notificationItem == currentItem
+            else { return }
         
-		finishedVideo?()
+        finishedVideo?()
         
         if let lastVideoURL = videoURLs?.last, currentVideoURL != lastVideoURL {
             playNextVideo()
         } else if shouldLoop {
             loopFromBeginning()
         } else {
-			stopVideo()
-		}
-	}
+            stopVideo()
+        }
+    }
     
     @objc internal func itemFailedToPlayToEndTime(_ notification: Notification) {
         let errorMessage = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey]
@@ -575,8 +577,8 @@ A simple UIView subclass that can play a video and allows animations to be appli
     
     fileprivate func skipToVideo(at index: Int) {
         guard index < videoItems.count, index >= 0 else {
-                stopVideo()
-                return
+            stopVideo()
+            return
         }
         
         swapCurrentItem(for: videoItems[index])

--- a/ASPVideoPlayer/Classes/AnimationForwarder.swift
+++ b/ASPVideoPlayer/Classes/AnimationForwarder.swift
@@ -9,18 +9,18 @@
 import UIKit
 
 /**
-Internal class used to forward the layer actions from the backing view to a layer.
-It should be used as the delegate of a layer.
-*/
+ Internal class used to forward the layer actions from the backing view to a layer.
+ It should be used as the delegate of a layer.
+ */
 internal class AnimationForwarder: UIView {
-	
-	fileprivate weak var backingView: UIView?
-	
-	internal convenience init(view: UIView) {
-		self.init()
-		backingView = view
-	}
-	
+    
+    fileprivate weak var backingView: UIView?
+    
+    internal convenience init(view: UIView) {
+        self.init()
+        backingView = view
+    }
+    
     override func action(for layer: CALayer, forKey event: String) -> CAAction? {
         return backingView?.action(for: layer, forKey: event)
     }

--- a/ASPVideoPlayer/Classes/ControlButtons.swift
+++ b/ASPVideoPlayer/Classes/ControlButtons.swift
@@ -9,126 +9,126 @@
 import UIKit
 
 /*
-Play and pause button.
-*/
+ Play and pause button.
+ */
 open class PlayPauseButton: UIButton {
-	public enum ButtonState {
-		case play
-		case pause
-	}
-	
-	open override var isSelected: Bool {
-		didSet {
-			if isSelected == true {
-				playPauseLayer.animationDirection = 0
-			} else {
-				playPauseLayer.animationDirection = 1
-			}
-		}
-	}
-	
-	open override var tintColor: UIColor? {
-		didSet {
-			playPauseLayer.color = tintColor ?? .white
-		}
-	}
-	
-	open var buttonState: ButtonState = .play {
-		didSet {
-			switch buttonState {
-			case .play:
-				isSelected = true
-			default:
-				isSelected = false
-			}
-		}
-	}
-	
-	private let playPauseLayer = PlayPauseLayer()
-	
-	override init(frame: CGRect) {
-		super.init(frame: frame)
-		
-		commonInit()
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-		
-		commonInit()
-	}
-	
-	open override func layoutSubviews() {
-		super.layoutSubviews()
-		playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
-		playPauseLayer.color = tintColor ?? .white
-	}
-	
-	@objc fileprivate func changeState() {
-		isSelected = !isSelected
-	}
-	
-	private func commonInit() {
-		playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
-		playPauseLayer.color = tintColor ?? .white
-		layer.addSublayer(playPauseLayer)
-		
-		addTarget(self, action: #selector(changeState), for: .touchUpInside)
-	}
+    public enum ButtonState {
+        case play
+        case pause
+    }
+    
+    open override var isSelected: Bool {
+        didSet {
+            if isSelected == true {
+                playPauseLayer.animationDirection = 0
+            } else {
+                playPauseLayer.animationDirection = 1
+            }
+        }
+    }
+    
+    open override var tintColor: UIColor? {
+        didSet {
+            playPauseLayer.color = tintColor ?? .white
+        }
+    }
+    
+    open var buttonState: ButtonState = .play {
+        didSet {
+            switch buttonState {
+            case .play:
+                isSelected = true
+            default:
+                isSelected = false
+            }
+        }
+    }
+    
+    private let playPauseLayer = PlayPauseLayer()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        commonInit()
+    }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
+        playPauseLayer.color = tintColor ?? .white
+    }
+    
+    @objc fileprivate func changeState() {
+        isSelected = !isSelected
+    }
+    
+    private func commonInit() {
+        playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
+        playPauseLayer.color = tintColor ?? .white
+        layer.addSublayer(playPauseLayer)
+        
+        addTarget(self, action: #selector(changeState), for: .touchUpInside)
+    }
 }
 
 /*
-Next button.
-*/
+ Next button.
+ */
 open class NextButton: UIButton {
-	override open func draw(_ rect: CGRect) {
-		if let context = UIGraphicsGetCurrentContext() {
-			context.setFillColor(tintColor.cgColor)
-			
-			let frame = bounds.insetBy(dx: bounds.width / 4.0 + 4.0, dy: bounds.height / 4.0 + 4.0)
-
-			context.move(to: frame.origin)
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.75, y: frame.origin.y + frame.size.height / 2.0))
-			context.addLine(to: CGPoint(x: frame.origin.x, y: (frame.origin.y + frame.size.height)))
-			context.closePath()
-			context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
-			context.fillPath()
-			
-			context.move(to: CGPoint(x: frame.origin.x + frame.size.width * 0.85, y: frame.origin.y))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y + frame.size.height))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.85, y: frame.origin.y + frame.size.height))
-			context.closePath()
-			context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
-			context.fillPath()
-		}
-	}
+    override open func draw(_ rect: CGRect) {
+        if let context = UIGraphicsGetCurrentContext() {
+            context.setFillColor(tintColor.cgColor)
+            
+            let frame = bounds.insetBy(dx: bounds.width / 4.0 + 4.0, dy: bounds.height / 4.0 + 4.0)
+            
+            context.move(to: frame.origin)
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.75, y: frame.origin.y + frame.size.height / 2.0))
+            context.addLine(to: CGPoint(x: frame.origin.x, y: (frame.origin.y + frame.size.height)))
+            context.closePath()
+            context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
+            context.fillPath()
+            
+            context.move(to: CGPoint(x: frame.origin.x + frame.size.width * 0.85, y: frame.origin.y))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y + frame.size.height))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.85, y: frame.origin.y + frame.size.height))
+            context.closePath()
+            context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
+            context.fillPath()
+        }
+    }
 }
 
 /*
-Previous button.
-*/
+ Previous button.
+ */
 open class PreviousButton: UIButton {
-	override open func draw(_ rect: CGRect) {
-		if let context = UIGraphicsGetCurrentContext() {
-			context.setFillColor(tintColor.cgColor)
-			
-			let frame = bounds.insetBy(dx: bounds.width / 4.0 + 4.0, dy: bounds.height / 4.0 + 4.0)
-			
-			context.move(to: frame.origin)
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.15, y: frame.origin.y))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.15, y: frame.origin.y + frame.size.height))
-			context.addLine(to: CGPoint(x: frame.origin.x, y: frame.origin.y + frame.size.height))
-			context.closePath()
-			context.setShadow(offset: CGSize(width: -0.5, height: 0.5), blur: 3.0)
-			context.fillPath()
-			
-			context.move(to: CGPoint(x: frame.origin.x + frame.size.width * 0.25, y: frame.origin.y + frame.size.height / 2.0))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y))
-			context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: (frame.origin.y + frame.size.height)))
-			context.closePath()
-			context.setShadow(offset: CGSize(width: -0.5, height: 0.5), blur: 3.0)
-			context.fillPath()
-		}
-	}
+    override open func draw(_ rect: CGRect) {
+        if let context = UIGraphicsGetCurrentContext() {
+            context.setFillColor(tintColor.cgColor)
+            
+            let frame = bounds.insetBy(dx: bounds.width / 4.0 + 4.0, dy: bounds.height / 4.0 + 4.0)
+            
+            context.move(to: frame.origin)
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.15, y: frame.origin.y))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width * 0.15, y: frame.origin.y + frame.size.height))
+            context.addLine(to: CGPoint(x: frame.origin.x, y: frame.origin.y + frame.size.height))
+            context.closePath()
+            context.setShadow(offset: CGSize(width: -0.5, height: 0.5), blur: 3.0)
+            context.fillPath()
+            
+            context.move(to: CGPoint(x: frame.origin.x + frame.size.width * 0.25, y: frame.origin.y + frame.size.height / 2.0))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: frame.origin.y))
+            context.addLine(to: CGPoint(x: frame.origin.x + frame.size.width, y: (frame.origin.y + frame.size.height)))
+            context.closePath()
+            context.setShadow(offset: CGSize(width: -0.5, height: 0.5), blur: 3.0)
+            context.fillPath()
+        }
+    }
 }

--- a/ASPVideoPlayer/Classes/ControlButtons.swift
+++ b/ASPVideoPlayer/Classes/ControlButtons.swift
@@ -27,9 +27,9 @@ open class PlayPauseButton: UIButton {
 		}
 	}
 	
-	open override var tintColor: UIColor! {
+	open override var tintColor: UIColor? {
 		didSet {
-			playPauseLayer.color = tintColor
+			playPauseLayer.color = tintColor ?? .white
 		}
 	}
 	
@@ -61,7 +61,7 @@ open class PlayPauseButton: UIButton {
 	open override func layoutSubviews() {
 		super.layoutSubviews()
 		playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
-		playPauseLayer.color = tintColor
+		playPauseLayer.color = tintColor ?? .white
 	}
 	
 	@objc fileprivate func changeState() {
@@ -70,7 +70,7 @@ open class PlayPauseButton: UIButton {
 	
 	private func commonInit() {
 		playPauseLayer.frame = bounds.insetBy(dx: (bounds.width / 4.0), dy: (bounds.height / 4.0))
-		playPauseLayer.color = tintColor
+		playPauseLayer.color = tintColor ?? .white
 		layer.addSublayer(playPauseLayer)
 		
 		addTarget(self, action: #selector(changeState), for: .touchUpInside)

--- a/ASPVideoPlayer/Classes/Loader.swift
+++ b/ASPVideoPlayer/Classes/Loader.swift
@@ -9,114 +9,114 @@
 import UIKit
 
 open class Loader: UIView {
-	
-	//MARK: - Private Variables and Constants -
-	
-	private let progressLayer = CAShapeLayer()
-	
-	//MARK: - Public Variables -
-	
-	/*
-	The width of the circle.
-	*/
-	open var lineWidth: CGFloat = 5.0
-	
-	//MARK: - Superclass methods -
-	
-	override init(frame: CGRect) {
-		super.init(frame: frame)
-		
-		self.layer.addSublayer(progressLayer)
-		backgroundColor = .clear
-		updatePath()
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-		
-		self.layer.addSublayer(progressLayer)
-		backgroundColor = .clear
-		updatePath()
-	}
-	
-	override open func layoutSubviews() {
-		super.layoutSubviews()
-		
-		progressLayer.frame = bounds
-		updatePath()
-	}
-	
-	//MARK: - Public methods -
-	
-	/*
-	Starts the loader animation.
-	*/
-	open func startAnimating() {
-		let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
-		rotationAnimation.duration = 4.0
-		rotationAnimation.fromValue = 0.0
-		rotationAnimation.toValue = 2.0 * .pi
-		rotationAnimation.repeatCount = .infinity
-		progressLayer.add(rotationAnimation, forKey: "rotationAnimation")
-		
-		let headAnimation = CABasicAnimation(keyPath: "strokeStart")
-		headAnimation.duration = 1.0
-		headAnimation.fromValue = 0.0
-		headAnimation.toValue = 0.25
-		headAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-		
-		let tailAnimation = CABasicAnimation(keyPath: "strokeEnd")
-		tailAnimation.duration = 1.0
-		tailAnimation.fromValue = 0.0
-		tailAnimation.toValue = 1.0
-		tailAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-		
-		let endHeadAnimation = CABasicAnimation(keyPath: "strokeStart")
-		endHeadAnimation.beginTime = 1.0
-		endHeadAnimation.duration = 0.5
-		endHeadAnimation.fromValue = 0.25
-		endHeadAnimation.toValue = 1.0
-		endHeadAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-		
-		let endTailAnimation = CABasicAnimation(keyPath: "strokeEnd")
-		endTailAnimation.beginTime = 1.0
-		endTailAnimation.duration = 0.5
-		endTailAnimation.fromValue = 1.0
-		endTailAnimation.toValue = 1.0
-		endTailAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-		
-		let animations = CAAnimationGroup()
-		animations.duration = 1.5
-		animations.animations = [headAnimation, tailAnimation, endHeadAnimation, endTailAnimation]
-		animations.repeatCount = .infinity
-		
-		
-		progressLayer.add(animations, forKey: "fillAnimations")
-	}
-	
-	/*
-	Stops the loader animation.
-	*/
-	open func stopAnimating() {
-		progressLayer.removeAllAnimations()
-	}
-	
-	//MARK: - Private methods -
-	
-	private func updatePath() {
-		let startAngle: CGFloat = 0.0
-		let endAngle: CGFloat = 2.0 * .pi
-		let radius: CGFloat = min(bounds.size.width / 2.0, bounds.size.height / 2.0)
-		let path = UIBezierPath(arcCenter: CGPoint(x: bounds.midX, y: bounds.midY), radius: radius - lineWidth / 2.0, startAngle: startAngle, endAngle: endAngle, clockwise: true)
-		
-		progressLayer.contentsScale = UIScreen.main.scale
-		
-		progressLayer.path = path.cgPath
-		
-		progressLayer.strokeColor = tintColor.cgColor
-		progressLayer.fillColor = backgroundColor?.cgColor
-		progressLayer.lineWidth = lineWidth
-		progressLayer.strokeStart = 0.0
-		progressLayer.strokeEnd = 0.0
-	}
+    
+    //MARK: - Private Variables and Constants -
+    
+    private let progressLayer = CAShapeLayer()
+    
+    //MARK: - Public Variables -
+    
+    /*
+     The width of the circle.
+     */
+    open var lineWidth: CGFloat = 5.0
+    
+    //MARK: - Superclass methods -
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.layer.addSublayer(progressLayer)
+        backgroundColor = .clear
+        updatePath()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        self.layer.addSublayer(progressLayer)
+        backgroundColor = .clear
+        updatePath()
+    }
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        
+        progressLayer.frame = bounds
+        updatePath()
+    }
+    
+    //MARK: - Public methods -
+    
+    /*
+     Starts the loader animation.
+     */
+    open func startAnimating() {
+        let rotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
+        rotationAnimation.duration = 4.0
+        rotationAnimation.fromValue = 0.0
+        rotationAnimation.toValue = 2.0 * .pi
+        rotationAnimation.repeatCount = .infinity
+        progressLayer.add(rotationAnimation, forKey: "rotationAnimation")
+        
+        let headAnimation = CABasicAnimation(keyPath: "strokeStart")
+        headAnimation.duration = 1.0
+        headAnimation.fromValue = 0.0
+        headAnimation.toValue = 0.25
+        headAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        
+        let tailAnimation = CABasicAnimation(keyPath: "strokeEnd")
+        tailAnimation.duration = 1.0
+        tailAnimation.fromValue = 0.0
+        tailAnimation.toValue = 1.0
+        tailAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        
+        let endHeadAnimation = CABasicAnimation(keyPath: "strokeStart")
+        endHeadAnimation.beginTime = 1.0
+        endHeadAnimation.duration = 0.5
+        endHeadAnimation.fromValue = 0.25
+        endHeadAnimation.toValue = 1.0
+        endHeadAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        
+        let endTailAnimation = CABasicAnimation(keyPath: "strokeEnd")
+        endTailAnimation.beginTime = 1.0
+        endTailAnimation.duration = 0.5
+        endTailAnimation.fromValue = 1.0
+        endTailAnimation.toValue = 1.0
+        endTailAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        
+        let animations = CAAnimationGroup()
+        animations.duration = 1.5
+        animations.animations = [headAnimation, tailAnimation, endHeadAnimation, endTailAnimation]
+        animations.repeatCount = .infinity
+        
+        
+        progressLayer.add(animations, forKey: "fillAnimations")
+    }
+    
+    /*
+     Stops the loader animation.
+     */
+    open func stopAnimating() {
+        progressLayer.removeAllAnimations()
+    }
+    
+    //MARK: - Private methods -
+    
+    private func updatePath() {
+        let startAngle: CGFloat = 0.0
+        let endAngle: CGFloat = 2.0 * .pi
+        let radius: CGFloat = min(bounds.size.width / 2.0, bounds.size.height / 2.0)
+        let path = UIBezierPath(arcCenter: CGPoint(x: bounds.midX, y: bounds.midY), radius: radius - lineWidth / 2.0, startAngle: startAngle, endAngle: endAngle, clockwise: true)
+        
+        progressLayer.contentsScale = UIScreen.main.scale
+        
+        progressLayer.path = path.cgPath
+        
+        progressLayer.strokeColor = tintColor.cgColor
+        progressLayer.fillColor = backgroundColor?.cgColor
+        progressLayer.lineWidth = lineWidth
+        progressLayer.strokeStart = 0.0
+        progressLayer.strokeEnd = 0.0
+    }
 }

--- a/ASPVideoPlayer/Classes/Math.swift
+++ b/ASPVideoPlayer/Classes/Math.swift
@@ -10,12 +10,12 @@ import Foundation
 import UIKit
 
 internal protocol NumericType: Comparable {
-	static func +(lhs: Self, rhs: Self) -> Self
-	static func -(lhs: Self, rhs: Self) -> Self
-	static func *(lhs: Self, rhs: Self) -> Self
-	static func /(lhs: Self, rhs: Self) -> Self
-	static func %(lhs: Self, rhs: Self) -> Self
-	init(_ v: Int)
+    static func +(lhs: Self, rhs: Self) -> Self
+    static func -(lhs: Self, rhs: Self) -> Self
+    static func *(lhs: Self, rhs: Self) -> Self
+    static func /(lhs: Self, rhs: Self) -> Self
+    static func %(lhs: Self, rhs: Self) -> Self
+    init(_ v: Int)
 }
 
 extension Double : NumericType { }
@@ -42,18 +42,18 @@ extension CGFloat : NumericType { }
 	- Parameter newMin: The minimum value of the new range.
 	- Parameter newMax: The maximum value of the new range.
 	- Ex. `value = 50.0, min = 0.0, max = 100.0, newMin = 0.0, newMax = 1.0 => newValue = 0.5`
-*/
+ */
 internal func rangeMap<T: NumericType>(_ value: T, min: T, max: T, newMin: T, newMax: T) -> T {
     return (((value - min) * (newMax - newMin)) / (max - min)) + newMin
 }
 
 /**
-Limits the value to the specified range.
-- Parameter value: The value to be limited.
-- Parameter lower: The minimum value of the range.
-- Parameter upper: The maximum value of the range.
-- Ex. `value = 50.0, lower = 0.0, uppermax = 40.0 => newValue = 40.0`
-*/
+ Limits the value to the specified range.
+ - Parameter value: The value to be limited.
+ - Parameter lower: The minimum value of the range.
+ - Parameter upper: The maximum value of the range.
+ - Ex. `value = 50.0, lower = 0.0, uppermax = 40.0 => newValue = 40.0`
+ */
 internal func clamp<T: NumericType>(_ value: T, lower: T, upper: T) -> T {
-	return min(max(value, lower), upper)
+    return min(max(value, lower), upper)
 }

--- a/ASPVideoPlayer/Classes/PlayPauseLayer.swift
+++ b/ASPVideoPlayer/Classes/PlayPauseLayer.swift
@@ -9,83 +9,83 @@
 import UIKit
 
 /*
-Internal class used for the play/pause animation on the PlayButton.
-*/
+ Internal class used for the play/pause animation on the PlayButton.
+ */
 internal class PlayPauseLayer: CALayer {
-	@NSManaged public var animationDirection: CGFloat
-	
-	public var color: UIColor = .black
-	
-	public override init() {
-		super.init()
-		contentsScale = UIScreen.main.scale
-		
-		CATransaction.begin()
-		CATransaction.setDisableActions(true)
-		animationDirection = 1.0
-		CATransaction.commit()
-	}
-	
-	public override init(layer: Any) {
-		super.init(layer: layer)
-		
-		if let layer = layer as? PlayPauseLayer {
-			animationDirection = layer.animationDirection
-			color = layer.color
-		}
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
-	
-	open override func draw(in context: CGContext) {
-		super.draw(in: context)
-		
-		let insetBounds = bounds.insetBy(dx: 4.0, dy: 4.0)
-		
-		let height: CGFloat = insetBounds.height
-		let itemWidth: CGFloat = insetBounds.width * 0.35
-		let targetWidth: CGFloat = ((insetBounds.width / 2.0) - itemWidth) * animationDirection
-		let width = itemWidth + targetWidth
-		
-		let firstItemHeight = height / 4.0 * animationDirection
-		let secondItemHeight = height / 2.0 * animationDirection
-		
-		context.move(to: CGPoint(x: insetBounds.origin.x, y: insetBounds.origin.y))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x + width, y: insetBounds.origin.y + firstItemHeight))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x + width, y: insetBounds.origin.y + height - firstItemHeight))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x, y: insetBounds.origin.y + height))
-		
-		context.move(to: CGPoint(x: insetBounds.origin.x + insetBounds.width - width, y: insetBounds.origin.y + firstItemHeight))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width, y: insetBounds.origin.y + secondItemHeight))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width, y: insetBounds.origin.y + height - secondItemHeight))
-		context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width - width, y: insetBounds.origin.y + height - firstItemHeight))
-		
-		context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
-		context.setFillColor(color.cgColor)
-		context.fillPath()
-	}
-	
-	open override func action(forKey event: String) -> CAAction? {
-		if event == "animationDirection" {
-			let basicAnimation = CABasicAnimation(keyPath: event)
-			basicAnimation.fromValue = animationDirection
-			basicAnimation.toValue = 1.0 - animationDirection
-			basicAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
-			basicAnimation.duration = 0.25
-			
-			return basicAnimation
-		}
-		
-		return super.action(forKey: event)
-	}
-	
-	open override class func needsDisplay(forKey key: String) -> Bool {
-		if key == "animationDirection" || key == "color" {
-			return true
-		}
-		
-		return super.needsDisplay(forKey: key)
-	}
+    @NSManaged public var animationDirection: CGFloat
+    
+    public var color: UIColor = .black
+    
+    public override init() {
+        super.init()
+        contentsScale = UIScreen.main.scale
+        
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        animationDirection = 1.0
+        CATransaction.commit()
+    }
+    
+    public override init(layer: Any) {
+        super.init(layer: layer)
+        
+        if let layer = layer as? PlayPauseLayer {
+            animationDirection = layer.animationDirection
+            color = layer.color
+        }
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    open override func draw(in context: CGContext) {
+        super.draw(in: context)
+        
+        let insetBounds = bounds.insetBy(dx: 4.0, dy: 4.0)
+        
+        let height: CGFloat = insetBounds.height
+        let itemWidth: CGFloat = insetBounds.width * 0.35
+        let targetWidth: CGFloat = ((insetBounds.width / 2.0) - itemWidth) * animationDirection
+        let width = itemWidth + targetWidth
+        
+        let firstItemHeight = height / 4.0 * animationDirection
+        let secondItemHeight = height / 2.0 * animationDirection
+        
+        context.move(to: CGPoint(x: insetBounds.origin.x, y: insetBounds.origin.y))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x + width, y: insetBounds.origin.y + firstItemHeight))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x + width, y: insetBounds.origin.y + height - firstItemHeight))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x, y: insetBounds.origin.y + height))
+        
+        context.move(to: CGPoint(x: insetBounds.origin.x + insetBounds.width - width, y: insetBounds.origin.y + firstItemHeight))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width, y: insetBounds.origin.y + secondItemHeight))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width, y: insetBounds.origin.y + height - secondItemHeight))
+        context.addLine(to: CGPoint(x: insetBounds.origin.x + insetBounds.width - width, y: insetBounds.origin.y + height - firstItemHeight))
+        
+        context.setShadow(offset: CGSize(width: 0.5, height: 0.5), blur: 3.0)
+        context.setFillColor(color.cgColor)
+        context.fillPath()
+    }
+    
+    open override func action(forKey event: String) -> CAAction? {
+        if event == "animationDirection" {
+            let basicAnimation = CABasicAnimation(keyPath: event)
+            basicAnimation.fromValue = animationDirection
+            basicAnimation.toValue = 1.0 - animationDirection
+            basicAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
+            basicAnimation.duration = 0.25
+            
+            return basicAnimation
+        }
+        
+        return super.action(forKey: event)
+    }
+    
+    open override class func needsDisplay(forKey key: String) -> Bool {
+        if key == "animationDirection" || key == "color" {
+            return true
+        }
+        
+        return super.needsDisplay(forKey: key)
+    }
 }

--- a/ASPVideoPlayer/Classes/Scrubber.swift
+++ b/ASPVideoPlayer/Classes/Scrubber.swift
@@ -109,10 +109,10 @@ open class Scrubber: UIControl {
 	/*
 	Sets the color of the thumb and track.
 	*/
-	open override var tintColor: UIColor! {
+	open override var tintColor: UIColor? {
 		didSet {
-			thumbColor = tintColor.cgColor
-			trackFillColor = tintColor.cgColor
+			thumbColor = tintColor?.cgColor ?? UIColor.white.cgColor
+			trackFillColor = tintColor?.cgColor ?? UIColor.white.cgColor
 		}
 	}
 	

--- a/ASPVideoPlayer/Classes/Scrubber.swift
+++ b/ASPVideoPlayer/Classes/Scrubber.swift
@@ -154,12 +154,7 @@ open class Scrubber: UIControl {
     }
     
     override open func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-        let location = touch.location(in: self)
-        
-        let clampedX = clamp(location.x, lower: bounds.origin.x + thumbWidth / 3.5, upper: bounds.size.width - thumbWidth / 3.5)
-        let deltaLocation = CGPoint(x: clampedX, y: location.y)
-        let deltaValue = rangeMap(deltaLocation.x, min: bounds.origin.x + thumbWidth / 3.5, max: bounds.size.width - thumbWidth / 3.5, newMin: minimumValue, newMax: maximumValue)
-        
+        let (deltaLocation, deltaValue) = deltaLocationAndValue(for: touch.location(in: self))
         previousLocation = deltaLocation
         
         if thumbLayer.highlighted {
@@ -204,7 +199,23 @@ open class Scrubber: UIControl {
         thumbLayer.shadowRadius = 2.0
         layer.addSublayer(thumbLayer)
         
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapScrubber(tapGesture:))))
+        
         updateFrames()
+    }
+    
+    @objc private func didTapScrubber(tapGesture: UITapGestureRecognizer) {
+        let (deltaLocation, deltaValue) = deltaLocationAndValue(for: tapGesture.location(in: self))
+        previousLocation = deltaLocation
+        value = deltaValue
+        sendActions(for: .valueChanged)
+    }
+    
+    private func deltaLocationAndValue(for pointInView: CGPoint) -> (CGPoint, CGFloat) {
+        let clampedX = clamp(pointInView.x, lower: bounds.origin.x + thumbWidth / 3.5, upper: bounds.size.width - thumbWidth / 3.5)
+        let deltaLocation = CGPoint(x: clampedX, y: pointInView.y)
+        let deltaValue = rangeMap(deltaLocation.x, min: bounds.origin.x + thumbWidth / 3.5, max: bounds.size.width - thumbWidth / 3.5, newMin: minimumValue, newMax: maximumValue)
+        return (deltaLocation, deltaValue)
     }
     
     private func updateFrames() {

--- a/ASPVideoPlayer/Classes/Scrubber.swift
+++ b/ASPVideoPlayer/Classes/Scrubber.swift
@@ -9,222 +9,222 @@
 import UIKit
 
 internal class ScrubberThumb: CALayer {
-	var highlighted = false
-	weak var scrubber: Scrubber?
+    var highlighted = false
+    weak var scrubber: Scrubber?
 }
 
 open class Scrubber: UIControl {
-	
-	//MARK: - Private Variables and Constants -
-	
-	private var previousLocation = CGPoint()
-	private let trackLayer = CALayer()
-	private let trackFillLayer = CALayer()
-	private let thumbLayer = ScrubberThumb()
-	
-	//MARK: - Public Variables -
-	
-	/*
-	Sets the minimum value of the scrubber. Defaults to 0.0 .
-	*/
-	open var minimumValue: CGFloat = 0.0  {
-		didSet {
-			updateFrames()
-		}
-	}
-	
-	/*
-	Sets the maximum value of the scrubber. Defaults to 1.0 .
-	*/
-	open var maximumValue: CGFloat = 1.0  {
-		didSet {
-			updateFrames()
-		}
-	}
-	
-	/*
-	The current value of the scrubber.
-	*/
-	open var value: CGFloat = 0.0  {
-		didSet {
-			if thumbLayer.highlighted == false {
-				let clampedValue = clamp(value, lower: minimumValue, upper: maximumValue)
-				let positionX = rangeMap(clampedValue, min: minimumValue, max: maximumValue, newMin: bounds.origin.x + thumbWidth / 2.0, newMax: bounds.size.width - thumbWidth / 2.0)
-				previousLocation = CGPoint(x: positionX, y: 0.0)
-			}
-			
-			updateFrames()
-			
-		}
-	}
-	
-	/*
-	The height of the track. Defaults to 6.0 .
-	*/
-	open var trackHeight: CGFloat = 6.0  {
-		didSet {
-			updateFrames()
-		}
-	}
-	
-	/*
-	Sets the color of the unfilled part of the track.
-	*/
-	open var trackColor = UIColor.white.withAlphaComponent(0.3).cgColor  {
-		didSet {
-			trackLayer.backgroundColor = trackColor
-			trackLayer.setNeedsDisplay()
-		}
-	}
-	
-	/*
-	Sets the color of the filled part of the track.
-	*/
-	open var trackFillColor = UIColor.white.cgColor  {
-		didSet {
-			trackFillLayer.backgroundColor = trackFillColor
-			trackFillLayer.setNeedsDisplay()
-		}
-	}
-	
-	/*
-	Sets the color of thumb.
-	*/
-	open var thumbColor = UIColor.white.cgColor  {
-		didSet {
-			thumbLayer.backgroundColor = thumbColor
-			thumbLayer.setNeedsDisplay()
-		}
-	}
-	
-	/*
-	Sets the width of the track.
-	*/
-	open var thumbWidth: CGFloat = 12.0  {
-		didSet {
-			updateFrames()
-		}
-	}
-	
-	/*
-	Sets the color of the thumb and track.
-	*/
-	open override var tintColor: UIColor? {
-		didSet {
-			thumbColor = tintColor?.cgColor ?? UIColor.white.cgColor
-			trackFillColor = tintColor?.cgColor ?? UIColor.white.cgColor
-		}
-	}
-	
-	//MARK: - Superclass methods -
-	
-	override init(frame: CGRect) {
-		super.init(frame: frame)
-		commonInit()
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-		commonInit()
-	}
-	
-	override open var frame: CGRect {
-		didSet {
-			updateFrames()
-		}
-	}
-	
-	override open func layoutSubviews() {
-		value = value + 0.0
-		updateFrames()
-	}
-	
-	//MARK: - UIControl methods -
-	
-	override open func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-		previousLocation = thumbLayer.position
-		
-		let extendedFrame = thumbLayer.frame.insetBy(dx: -thumbWidth * 1.5, dy: -thumbWidth * 1.5)
-		if extendedFrame.contains(touch.location(in: self)) {
-			sendActions(for: .touchDown)
-			thumbLayer.highlighted = true
-			thumbWidth = 20.0
-		}
-		return thumbLayer.highlighted
-	}
-	
-	override open func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-		let location = touch.location(in: self)
-		
-		let clampedX = clamp(location.x, lower: bounds.origin.x + thumbWidth / 3.5, upper: bounds.size.width - thumbWidth / 3.5)
-		let deltaLocation = CGPoint(x: clampedX, y: location.y)
-		let deltaValue = rangeMap(deltaLocation.x, min: bounds.origin.x + thumbWidth / 3.5, max: bounds.size.width - thumbWidth / 3.5, newMin: minimumValue, newMax: maximumValue)
-		
-		previousLocation = deltaLocation
-		
-		if thumbLayer.highlighted {
-			value = deltaValue
-			sendActions(for: .valueChanged)
-		}
-		
-		return thumbLayer.highlighted
-	}
-	
-	override open func endTracking(_ touch: UITouch?, with event: UIEvent?) {
-		thumbLayer.highlighted = false
-		thumbWidth = 12.0
-		
-		sendActions(for: .touchUpInside)
-	}
-	
-	open override func cancelTracking(with event: UIEvent?) {
-		thumbLayer.highlighted = false
-		thumbWidth = 12.0
-		
-		sendActions(for: .touchCancel)
-	}
-	
-	//MARK: - Private Methods -
-	
-	private func commonInit() {
-		thumbLayer.scrubber = self
-		
-		trackLayer.backgroundColor = trackColor
-		layer.addSublayer(trackLayer)
-		
-		trackFillLayer.backgroundColor = trackFillColor
-		layer.addSublayer(trackFillLayer)
-		
-		thumbLayer.backgroundColor = thumbColor
-		thumbLayer.borderColor = UIColor.black.withAlphaComponent(0.1).cgColor
-		thumbLayer.borderWidth = 0.5
-		thumbLayer.shadowColor = UIColor.black.cgColor
-		thumbLayer.shadowOffset = CGSize(width: 1.5, height: 1.5)
-		thumbLayer.shadowOpacity = 0.35
-		thumbLayer.shadowRadius = 2.0
-		layer.addSublayer(thumbLayer)
-		
-		updateFrames()
-	}
-	
-	private func updateFrames() {
-		CATransaction.begin()
-		CATransaction.setDisableActions(true)
-		
-		trackLayer.frame = CGRect(x: 0.0, y: bounds.height / 2.0, width: bounds.width, height: trackHeight)
-		trackLayer.cornerRadius = trackHeight / 2.0
-		trackLayer.setNeedsDisplay()
-		
-		let thumbCenter = CGPoint(x: previousLocation.x - thumbWidth / 2.0, y: bounds.midY)
-		let thumbSize = thumbWidth * 1.0
-		thumbLayer.frame = CGRect(x: thumbCenter.x, y: trackLayer.frame.midY - thumbSize / 2.0 , width: thumbSize, height: thumbSize)
-		thumbLayer.cornerRadius = thumbSize / 2.0
-		thumbLayer.setNeedsDisplay()
-		
-		trackFillLayer.frame = CGRect(origin: trackLayer.frame.origin, size: CGSize(width: thumbCenter.x + thumbSize, height: trackHeight))
-		trackFillLayer.cornerRadius = trackHeight / 2.0
-		trackFillLayer.setNeedsDisplay()
-		
-		CATransaction.commit()
-	}
+    
+    //MARK: - Private Variables and Constants -
+    
+    private var previousLocation = CGPoint()
+    private let trackLayer = CALayer()
+    private let trackFillLayer = CALayer()
+    private let thumbLayer = ScrubberThumb()
+    
+    //MARK: - Public Variables -
+    
+    /*
+     Sets the minimum value of the scrubber. Defaults to 0.0 .
+     */
+    open var minimumValue: CGFloat = 0.0  {
+        didSet {
+            updateFrames()
+        }
+    }
+    
+    /*
+     Sets the maximum value of the scrubber. Defaults to 1.0 .
+     */
+    open var maximumValue: CGFloat = 1.0  {
+        didSet {
+            updateFrames()
+        }
+    }
+    
+    /*
+     The current value of the scrubber.
+     */
+    open var value: CGFloat = 0.0  {
+        didSet {
+            if thumbLayer.highlighted == false {
+                let clampedValue = clamp(value, lower: minimumValue, upper: maximumValue)
+                let positionX = rangeMap(clampedValue, min: minimumValue, max: maximumValue, newMin: bounds.origin.x + thumbWidth / 2.0, newMax: bounds.size.width - thumbWidth / 2.0)
+                previousLocation = CGPoint(x: positionX, y: 0.0)
+            }
+            
+            updateFrames()
+            
+        }
+    }
+    
+    /*
+     The height of the track. Defaults to 6.0 .
+     */
+    open var trackHeight: CGFloat = 6.0  {
+        didSet {
+            updateFrames()
+        }
+    }
+    
+    /*
+     Sets the color of the unfilled part of the track.
+     */
+    open var trackColor = UIColor.white.withAlphaComponent(0.3).cgColor  {
+        didSet {
+            trackLayer.backgroundColor = trackColor
+            trackLayer.setNeedsDisplay()
+        }
+    }
+    
+    /*
+     Sets the color of the filled part of the track.
+     */
+    open var trackFillColor = UIColor.white.cgColor  {
+        didSet {
+            trackFillLayer.backgroundColor = trackFillColor
+            trackFillLayer.setNeedsDisplay()
+        }
+    }
+    
+    /*
+     Sets the color of thumb.
+     */
+    open var thumbColor = UIColor.white.cgColor  {
+        didSet {
+            thumbLayer.backgroundColor = thumbColor
+            thumbLayer.setNeedsDisplay()
+        }
+    }
+    
+    /*
+     Sets the width of the track.
+     */
+    open var thumbWidth: CGFloat = 12.0  {
+        didSet {
+            updateFrames()
+        }
+    }
+    
+    /*
+     Sets the color of the thumb and track.
+     */
+    open override var tintColor: UIColor? {
+        didSet {
+            thumbColor = tintColor?.cgColor ?? UIColor.white.cgColor
+            trackFillColor = tintColor?.cgColor ?? UIColor.white.cgColor
+        }
+    }
+    
+    //MARK: - Superclass methods -
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override open var frame: CGRect {
+        didSet {
+            updateFrames()
+        }
+    }
+    
+    override open func layoutSubviews() {
+        value = value + 0.0
+        updateFrames()
+    }
+    
+    //MARK: - UIControl methods -
+    
+    override open func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        previousLocation = thumbLayer.position
+        
+        let extendedFrame = thumbLayer.frame.insetBy(dx: -thumbWidth * 1.5, dy: -thumbWidth * 1.5)
+        if extendedFrame.contains(touch.location(in: self)) {
+            sendActions(for: .touchDown)
+            thumbLayer.highlighted = true
+            thumbWidth = 20.0
+        }
+        return thumbLayer.highlighted
+    }
+    
+    override open func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        let location = touch.location(in: self)
+        
+        let clampedX = clamp(location.x, lower: bounds.origin.x + thumbWidth / 3.5, upper: bounds.size.width - thumbWidth / 3.5)
+        let deltaLocation = CGPoint(x: clampedX, y: location.y)
+        let deltaValue = rangeMap(deltaLocation.x, min: bounds.origin.x + thumbWidth / 3.5, max: bounds.size.width - thumbWidth / 3.5, newMin: minimumValue, newMax: maximumValue)
+        
+        previousLocation = deltaLocation
+        
+        if thumbLayer.highlighted {
+            value = deltaValue
+            sendActions(for: .valueChanged)
+        }
+        
+        return thumbLayer.highlighted
+    }
+    
+    override open func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+        thumbLayer.highlighted = false
+        thumbWidth = 12.0
+        
+        sendActions(for: .touchUpInside)
+    }
+    
+    open override func cancelTracking(with event: UIEvent?) {
+        thumbLayer.highlighted = false
+        thumbWidth = 12.0
+        
+        sendActions(for: .touchCancel)
+    }
+    
+    //MARK: - Private Methods -
+    
+    private func commonInit() {
+        thumbLayer.scrubber = self
+        
+        trackLayer.backgroundColor = trackColor
+        layer.addSublayer(trackLayer)
+        
+        trackFillLayer.backgroundColor = trackFillColor
+        layer.addSublayer(trackFillLayer)
+        
+        thumbLayer.backgroundColor = thumbColor
+        thumbLayer.borderColor = UIColor.black.withAlphaComponent(0.1).cgColor
+        thumbLayer.borderWidth = 0.5
+        thumbLayer.shadowColor = UIColor.black.cgColor
+        thumbLayer.shadowOffset = CGSize(width: 1.5, height: 1.5)
+        thumbLayer.shadowOpacity = 0.35
+        thumbLayer.shadowRadius = 2.0
+        layer.addSublayer(thumbLayer)
+        
+        updateFrames()
+    }
+    
+    private func updateFrames() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        
+        trackLayer.frame = CGRect(x: 0.0, y: bounds.height / 2.0, width: bounds.width, height: trackHeight)
+        trackLayer.cornerRadius = trackHeight / 2.0
+        trackLayer.setNeedsDisplay()
+        
+        let thumbCenter = CGPoint(x: previousLocation.x - thumbWidth / 2.0, y: bounds.midY)
+        let thumbSize = thumbWidth * 1.0
+        thumbLayer.frame = CGRect(x: thumbCenter.x, y: trackLayer.frame.midY - thumbSize / 2.0 , width: thumbSize, height: thumbSize)
+        thumbLayer.cornerRadius = thumbSize / 2.0
+        thumbLayer.setNeedsDisplay()
+        
+        trackFillLayer.frame = CGRect(origin: trackLayer.frame.origin, size: CGSize(width: thumbCenter.x + thumbSize, height: trackHeight))
+        trackFillLayer.cornerRadius = trackHeight / 2.0
+        trackFillLayer.setNeedsDisplay()
+        
+        CATransaction.commit()
+    }
 }

--- a/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
+++ b/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 				0572317B3DBC9AC5420A16F7 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		607FACD11AFB9204008FA782 /* Products */ = {
 			isa = PBXGroup;
@@ -281,7 +282,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
 				LastUpgradeCheck = 0830;
-				ORGANIZATIONNAME = CocoaPods;
+				ORGANIZATIONNAME = "Andrei-Sergiu Pițiș";
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;

--- a/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
+++ b/Example/ASPVideoPlayer.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		75C633221E054198000DBD42 /* ASPVideoPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C633211E054198000DBD42 /* ASPVideoPlayerTests.swift */; };
 		75C6332A1E056478000DBD42 /* ASPVideoPlayer_ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C633291E056478000DBD42 /* ASPVideoPlayer_ExampleUITests.swift */; };
 		82AABB55DE4BABA586F5C65B /* Pods_ASPVideoPlayer_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 657113FC20D81D253680D24D /* Pods_ASPVideoPlayer_Example.framework */; };
+		D4333F6C1EA10284000FC9B7 /* ASPTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4333F6A1EA10246000FC9B7 /* ASPTestCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		75C633291E056478000DBD42 /* ASPVideoPlayer_ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASPVideoPlayer_ExampleUITests.swift; sourceTree = "<group>"; };
 		75C6332B1E056478000DBD42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8179CAB6F1755BD934B98047 /* Pods-ASPVideoPlayer_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ASPVideoPlayer_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-ASPVideoPlayer_Example/Pods-ASPVideoPlayer_Example.release.xcconfig"; sourceTree = "<group>"; };
+		D4333F6A1EA10246000FC9B7 /* ASPTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASPTestCase.swift; sourceTree = "<group>"; };
 		D4D561E4D863E435F2EE8D02 /* Pods_ASPVideoPlayer_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ASPVideoPlayer_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E46EEA47B4689CB9C4BB8112 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -160,6 +162,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D4333F6A1EA10246000FC9B7 /* ASPTestCase.swift */,
 				75C6331C1E040D91000DBD42 /* ViewControllerTests.swift */,
 				75C633211E054198000DBD42 /* ASPVideoPlayerTests.swift */,
 				75093D881D14C1CA0054E08D /* ASPVideoPlayerControlsTests.swift */,
@@ -461,6 +464,7 @@
 				75093D8A1D14C1CA0054E08D /* ASPVideoPlayerControlsTests.swift in Sources */,
 				75093D8B1D14C1CA0054E08D /* ASPVideoPlayerViewTests.swift in Sources */,
 				75C633221E054198000DBD42 /* ASPVideoPlayerTests.swift in Sources */,
+				D4333F6C1EA10284000FC9B7 /* ASPTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
+++ b/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
@@ -74,6 +74,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
@@ -104,6 +109,11 @@
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
+++ b/Example/ASPVideoPlayer.xcodeproj/xcshareddata/xcschemes/ASPVideoPlayer-Example.xcscheme
@@ -109,11 +109,6 @@
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/Example/ASPVideoPlayer/AppDelegate.swift
+++ b/Example/ASPVideoPlayer/AppDelegate.swift
@@ -10,9 +10,9 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/Example/ASPVideoPlayer/PlayerViewController.swift
+++ b/Example/ASPVideoPlayer/PlayerViewController.swift
@@ -24,6 +24,7 @@ class PlayerViewController: UIViewController {
 		videoPlayer.videoURLs = [firstLocalVideoURL!, secondLocalVideoURL!, firstNetworkURL!, secondNetworkURL!]
 		videoPlayer.gravity = .aspectFit
 		videoPlayer.shouldLoop = true
+        videoPlayer.videoPlayerControls.timeFont = UIFont.systemFont(ofSize: 12)
 	}
 	
 }

--- a/Example/ASPVideoPlayer/PlayerViewController.swift
+++ b/Example/ASPVideoPlayer/PlayerViewController.swift
@@ -22,8 +22,8 @@ class PlayerViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		videoPlayer.videoURLs = [firstLocalVideoURL!, secondLocalVideoURL!, firstNetworkURL!, secondNetworkURL!]
-		videoPlayer.gravity = .aspectFit
-		videoPlayer.shouldLoop = true
+		videoPlayer.videoPlayerView.gravity = .aspectFit
+		videoPlayer.videoPlayerView.shouldLoop = true
         videoPlayer.videoPlayerControls.timeFont = UIFont.systemFont(ofSize: 12)
 	}
 	

--- a/Example/ASPVideoPlayer/PlayerViewController.swift
+++ b/Example/ASPVideoPlayer/PlayerViewController.swift
@@ -11,20 +11,22 @@ import ASPVideoPlayer
 
 class PlayerViewController: UIViewController {
 	
-	@IBOutlet weak var videoPlayer: ASPVideoPlayer!
-	
-	let firstLocalVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
-	let secondLocalVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4")
-	
-	let firstNetworkURL = URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")
-	let secondNetworkURL = URL(string: "http://www.easy-fit.ae/wp-content/uploads/2014/09/WebsiteLoop.mp4")
+	@IBOutlet weak var videoPlayer: ASPVideoPlayer?
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		videoPlayer.videoURLs = [firstLocalVideoURL!, secondLocalVideoURL!, firstNetworkURL!, secondNetworkURL!]
-		videoPlayer.videoPlayerView.gravity = .aspectFit
-		videoPlayer.videoPlayerView.shouldLoop = true
-        videoPlayer.videoPlayerControls.timeFont = UIFont.systemFont(ofSize: 12)
+        
+        guard let videoPlayer = videoPlayer,
+              let firstLocalVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4"),
+              let secondLocalVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4"),
+              let firstNetworkURL = URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8"),
+              let secondNetworkURL = URL(string: "http://www.easy-fit.ae/wp-content/uploads/2014/09/WebsiteLoop.mp4")
+        else { return }
+        
+		videoPlayer.videoURLs = [firstLocalVideoURL, secondLocalVideoURL, firstNetworkURL, secondNetworkURL]
+		videoPlayer.videoPlayerView?.gravity = .aspectFit
+		videoPlayer.videoPlayerView?.shouldLoop = true
+        videoPlayer.videoPlayerControls?.timeFont = UIFont.systemFont(ofSize: 12)
 	}
 	
 }

--- a/Example/ASPVideoPlayer/PlayerViewController.swift
+++ b/Example/ASPVideoPlayer/PlayerViewController.swift
@@ -15,18 +15,18 @@ class PlayerViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-        
-        guard let videoPlayer = videoPlayer,
-              let firstLocalVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4"),
-              let secondLocalVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4"),
-              let firstNetworkURL = URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8"),
-              let secondNetworkURL = URL(string: "http://www.easy-fit.ae/wp-content/uploads/2014/09/WebsiteLoop.mp4")
-        else { return }
-        
+		
+		guard let videoPlayer = videoPlayer,
+			  let firstLocalVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4"),
+			  let secondLocalVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4"),
+			  let firstNetworkURL = URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8"),
+			  let secondNetworkURL = URL(string: "http://www.easy-fit.ae/wp-content/uploads/2014/09/WebsiteLoop.mp4")
+			else { return }
+		
 		videoPlayer.videoURLs = [firstLocalVideoURL, secondLocalVideoURL, firstNetworkURL, secondNetworkURL]
 		videoPlayer.videoPlayerView?.gravity = .aspectFit
 		videoPlayer.videoPlayerView?.shouldLoop = true
-        videoPlayer.videoPlayerControls?.timeFont = UIFont.systemFont(ofSize: 12)
+		videoPlayer.videoPlayerControls?.timeFont = UIFont.systemFont(ofSize: 12)
 	}
 	
 }

--- a/Example/ASPVideoPlayer/ViewController.swift
+++ b/Example/ASPVideoPlayer/ViewController.swift
@@ -10,84 +10,84 @@ import UIKit
 import ASPVideoPlayer
 
 class ViewController: UIViewController {
-	@IBOutlet weak var videoTopConstraint: NSLayoutConstraint?
-	@IBOutlet weak var videoBottomConstraint: NSLayoutConstraint?
-	@IBOutlet weak var videoLeadingConstraint: NSLayoutConstraint?
-	@IBOutlet weak var videoTrailingConstraint: NSLayoutConstraint?
-	@IBOutlet weak var videoPlayer: ASPVideoPlayerView?
-	
-	let firstVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
-	let secondVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4")
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-
-		videoPlayer?.videoURL = firstVideoURL
-		videoPlayer?.gravity = .aspectFit
-		videoPlayer?.shouldLoop = true
-		videoPlayer?.startPlayingWhenReady = true
-		
-		videoPlayer?.backgroundColor = UIColor.black
-		
-		videoPlayer?.newVideo = {
-			print("newVideo")
-		}
-		
-		videoPlayer?.readyToPlayVideo = {
-			print("readyToPlay")
-		}
-		
-		videoPlayer?.startedVideo = {
-			print("start")
-			
-		}
-		
+    @IBOutlet weak var videoTopConstraint: NSLayoutConstraint?
+    @IBOutlet weak var videoBottomConstraint: NSLayoutConstraint?
+    @IBOutlet weak var videoLeadingConstraint: NSLayoutConstraint?
+    @IBOutlet weak var videoTrailingConstraint: NSLayoutConstraint?
+    @IBOutlet weak var videoPlayer: ASPVideoPlayerView?
+    
+    let firstVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
+    let secondVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        videoPlayer?.videoURL = firstVideoURL
+        videoPlayer?.gravity = .aspectFit
+        videoPlayer?.shouldLoop = true
+        videoPlayer?.startPlayingWhenReady = true
+        
+        videoPlayer?.backgroundColor = UIColor.black
+        
+        videoPlayer?.newVideo = {
+            print("newVideo")
+        }
+        
+        videoPlayer?.readyToPlayVideo = {
+            print("readyToPlay")
+        }
+        
+        videoPlayer?.startedVideo = {
+            print("start")
+            
+        }
+        
         videoPlayer?.finishedVideo = { [weak self] in
             guard let strongSelf = self else { return }
             
-			print("finishedVideo")
+            print("finishedVideo")
             if strongSelf.videoPlayer?.videoURL == strongSelf.firstVideoURL {
-				strongSelf.videoPlayer?.startPlayingWhenReady = true
-				strongSelf.videoPlayer?.videoURL = strongSelf.secondVideoURL
-			}
-			
-			UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
-				strongSelf.videoTopConstraint?.constant = 150.0
-				strongSelf.videoBottomConstraint?.constant = 150.0
-				strongSelf.videoLeadingConstraint?.constant = 150.0
-				strongSelf.videoTrailingConstraint?.constant = 150.0
-				strongSelf.view.layoutIfNeeded()
-				}, completion: { (finished) in
-					UIView.animate(withDuration: 0.3, delay: 1.0, options: .curveEaseIn, animations: {
-						
-						strongSelf.videoTopConstraint?.constant = 0.0
-						strongSelf.videoBottomConstraint?.constant = 0.0
-						strongSelf.videoLeadingConstraint?.constant = 0.0
-						strongSelf.videoTrailingConstraint?.constant = 0.0
-						
-						strongSelf.view.layoutIfNeeded()
-						}, completion: { (finished) in
-							
-					})
-			})
-		}
-		
-		videoPlayer?.playingVideo = { (progress) -> Void in
+                strongSelf.videoPlayer?.startPlayingWhenReady = true
+                strongSelf.videoPlayer?.videoURL = strongSelf.secondVideoURL
+            }
+            
+            UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
+                strongSelf.videoTopConstraint?.constant = 150.0
+                strongSelf.videoBottomConstraint?.constant = 150.0
+                strongSelf.videoLeadingConstraint?.constant = 150.0
+                strongSelf.videoTrailingConstraint?.constant = 150.0
+                strongSelf.view.layoutIfNeeded()
+            }, completion: { (finished) in
+                UIView.animate(withDuration: 0.3, delay: 1.0, options: .curveEaseIn, animations: {
+                    
+                    strongSelf.videoTopConstraint?.constant = 0.0
+                    strongSelf.videoBottomConstraint?.constant = 0.0
+                    strongSelf.videoLeadingConstraint?.constant = 0.0
+                    strongSelf.videoTrailingConstraint?.constant = 0.0
+                    
+                    strongSelf.view.layoutIfNeeded()
+                }, completion: { (finished) in
+                    
+                })
+            })
+        }
+        
+        videoPlayer?.playingVideo = { (progress) -> Void in
             let progressString = String.localizedStringWithFormat("%.2f", progress * 100)
-			print("progress: \(progressString) % complete.")
-		}
-		
-		videoPlayer?.pausedVideo = {
-			print("paused")
-		}
-		
-		videoPlayer?.stoppedVideo = {
-			print("stopped")
-		}
-		
-		videoPlayer?.error = { (error) -> Void in
-			print("Error: \(error.localizedDescription)")
-		}
-	}
+            print("progress: \(progressString) % complete.")
+        }
+        
+        videoPlayer?.pausedVideo = {
+            print("paused")
+        }
+        
+        videoPlayer?.stoppedVideo = {
+            print("stopped")
+        }
+        
+        videoPlayer?.error = { (error) -> Void in
+            print("Error: \(error.localizedDescription)")
+        }
+    }
 }
 

--- a/Example/ASPVideoPlayer/ViewController.swift
+++ b/Example/ASPVideoPlayer/ViewController.swift
@@ -10,11 +10,11 @@ import UIKit
 import ASPVideoPlayer
 
 class ViewController: UIViewController {
-	@IBOutlet weak var videoTopConstraint: NSLayoutConstraint!
-	@IBOutlet weak var videoBottomConstraint: NSLayoutConstraint!
-	@IBOutlet weak var videoLeadingConstraint: NSLayoutConstraint!
-	@IBOutlet weak var videoTrailingConstraint: NSLayoutConstraint!
-	@IBOutlet weak var videoPlayer: ASPVideoPlayerView!
+	@IBOutlet weak var videoTopConstraint: NSLayoutConstraint?
+	@IBOutlet weak var videoBottomConstraint: NSLayoutConstraint?
+	@IBOutlet weak var videoLeadingConstraint: NSLayoutConstraint?
+	@IBOutlet weak var videoTrailingConstraint: NSLayoutConstraint?
+	@IBOutlet weak var videoPlayer: ASPVideoPlayerView?
 	
 	let firstVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
 	let secondVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4")
@@ -22,48 +22,48 @@ class ViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-		videoPlayer.videoURL = firstVideoURL
-		videoPlayer.gravity = .aspectFit
-		videoPlayer.shouldLoop = true
-		videoPlayer.startPlayingWhenReady = true
+		videoPlayer?.videoURL = firstVideoURL
+		videoPlayer?.gravity = .aspectFit
+		videoPlayer?.shouldLoop = true
+		videoPlayer?.startPlayingWhenReady = true
 		
-		videoPlayer.backgroundColor = UIColor.black
+		videoPlayer?.backgroundColor = UIColor.black
 		
-		videoPlayer.newVideo = {
+		videoPlayer?.newVideo = {
 			print("newVideo")
 		}
 		
-		videoPlayer.readyToPlayVideo = {
+		videoPlayer?.readyToPlayVideo = {
 			print("readyToPlay")
 		}
 		
-		videoPlayer.startedVideo = {
+		videoPlayer?.startedVideo = {
 			print("start")
 			
 		}
 		
-        videoPlayer.finishedVideo = { [weak self] in
+        videoPlayer?.finishedVideo = { [weak self] in
             guard let strongSelf = self else { return }
             
 			print("finishedVideo")
-            if strongSelf.videoPlayer.videoURL == strongSelf.firstVideoURL {
-				strongSelf.videoPlayer.startPlayingWhenReady = true
-				strongSelf.videoPlayer.videoURL = strongSelf.secondVideoURL
+            if strongSelf.videoPlayer?.videoURL == strongSelf.firstVideoURL {
+				strongSelf.videoPlayer?.startPlayingWhenReady = true
+				strongSelf.videoPlayer?.videoURL = strongSelf.secondVideoURL
 			}
 			
 			UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
-				strongSelf.videoTopConstraint.constant = 150.0
-				strongSelf.videoBottomConstraint.constant = 150.0
-				strongSelf.videoLeadingConstraint.constant = 150.0
-				strongSelf.videoTrailingConstraint.constant = 150.0
+				strongSelf.videoTopConstraint?.constant = 150.0
+				strongSelf.videoBottomConstraint?.constant = 150.0
+				strongSelf.videoLeadingConstraint?.constant = 150.0
+				strongSelf.videoTrailingConstraint?.constant = 150.0
 				strongSelf.view.layoutIfNeeded()
 				}, completion: { (finished) in
 					UIView.animate(withDuration: 0.3, delay: 1.0, options: .curveEaseIn, animations: {
 						
-						strongSelf.videoTopConstraint.constant = 0.0
-						strongSelf.videoBottomConstraint.constant = 0.0
-						strongSelf.videoLeadingConstraint.constant = 0.0
-						strongSelf.videoTrailingConstraint.constant = 0.0
+						strongSelf.videoTopConstraint?.constant = 0.0
+						strongSelf.videoBottomConstraint?.constant = 0.0
+						strongSelf.videoLeadingConstraint?.constant = 0.0
+						strongSelf.videoTrailingConstraint?.constant = 0.0
 						
 						strongSelf.view.layoutIfNeeded()
 						}, completion: { (finished) in
@@ -72,20 +72,20 @@ class ViewController: UIViewController {
 			})
 		}
 		
-		videoPlayer.playingVideo = { (progress) -> Void in
-            let progressString = String.localizedStringWithFormat("%.2f", progress)
+		videoPlayer?.playingVideo = { (progress) -> Void in
+            let progressString = String.localizedStringWithFormat("%.2f", progress * 100)
 			print("progress: \(progressString) % complete.")
 		}
 		
-		videoPlayer.pausedVideo = {
+		videoPlayer?.pausedVideo = {
 			print("paused")
 		}
 		
-		videoPlayer.stoppedVideo = {
+		videoPlayer?.stoppedVideo = {
 			print("stopped")
 		}
 		
-		videoPlayer.error = { (error) -> Void in
+		videoPlayer?.error = { (error) -> Void in
 			print("Error: \(error.localizedDescription)")
 		}
 	}

--- a/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
+++ b/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
@@ -32,6 +32,8 @@ class ASPVideoPlayer_ExampleUITests: XCTestCase {
 		let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element
 		let button = element.children(matching: .other).element(boundBy: 1).children(matching: .button).element(boundBy: 0)
 		button.tap()
+        
+        element.children(matching: .other).element(boundBy: 0).tap()
 
 		XCTAssertEqual(button.isSelected, true, "Button is not selected.")
 	}
@@ -51,6 +53,7 @@ class ASPVideoPlayer_ExampleUITests: XCTestCase {
         startCoordinate.press(forDuration: 0.0, thenDragTo: destinationCoordinate)
 		
 		XCTAssertNotEqual(labelValue.label, "00:00:00", "Values are equal.")
+        XCTAssertNotEqual(labelValue.label, "00:00", "Values are equal.")
 	}
 	
 	func testTapVideo_ShouldHideControls() {

--- a/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
+++ b/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
@@ -9,38 +9,38 @@
 import XCTest
 
 class ASPVideoPlayer_ExampleUITests: XCTestCase {
-	
-	override func setUp() {
-		super.setUp()
-		
-		// Put setup code here. This method is called before the invocation of each test method in the class.
-		
-		// In UI tests it is usually best to stop immediately when a failure occurs.
-		continueAfterFailure = false
-		// UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-		XCUIApplication().launch()
-		
-		// In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-	}
-	
-	override func tearDown() {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-		super.tearDown()
-	}
-
-	func testPressPlayButtons_ShouldSelectPlayButton() {
-		let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element
-		let button = element.children(matching: .other).element(boundBy: 1).children(matching: .button).element(boundBy: 0)
-		button.tap()
+    
+    override func setUp() {
+        super.setUp()
+        
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+        
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testPressPlayButtons_ShouldSelectPlayButton() {
+        let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element
+        let button = element.children(matching: .other).element(boundBy: 1).children(matching: .button).element(boundBy: 0)
+        button.tap()
         
         element.children(matching: .other).element(boundBy: 0).tap()
-
-		XCTAssertEqual(button.isSelected, true, "Button is not selected.")
-	}
-	
-	func testAdjustScrubber_ShouldSeekVideo() {
+        
+        XCTAssertEqual(button.isSelected, true, "Button is not selected.")
+    }
+    
+    func testAdjustScrubber_ShouldSeekVideo() {
         let app = XCUIApplication()
-		let element = app.children(matching: .window).element(boundBy: 0)
+        let element = app.children(matching: .window).element(boundBy: 0)
         let labelValue = app.staticTexts.element(boundBy: 0)
         
         let screenSize = element.frame.size
@@ -51,30 +51,30 @@ class ASPVideoPlayer_ExampleUITests: XCTestCase {
         let destinationCoordinate: XCUICoordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 1.0))
         
         startCoordinate.press(forDuration: 0.0, thenDragTo: destinationCoordinate)
-		
-		XCTAssertNotEqual(labelValue.label, "00:00:00", "Values are equal.")
+        
+        XCTAssertNotEqual(labelValue.label, "00:00:00", "Values are equal.")
         XCTAssertNotEqual(labelValue.label, "00:00", "Values are equal.")
-	}
-	
-	func testTapVideo_ShouldHideControls() {
-		let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 1)
-		let button = element.children(matching: .button).element(boundBy: 0)
-		button.tap()
-		
-		sleep(4)
-
-		XCTAssertEqual(element.exists, false, "Controls are visible.")
-	}
-	
-	func testTapVideoWhenControlsHidden_ShouldShowControls() {
-		let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element
-		let button = element.children(matching: .other).element(boundBy: 1).children(matching: .button).element(boundBy: 0)
-		button.tap()
-		
-		sleep(4)
-		
-		element.children(matching: .other).element(boundBy: 0).tap()
-
-		XCTAssertEqual(element.exists, true, "Controls are not visible.")
-	}
+    }
+    
+    func testTapVideo_ShouldHideControls() {
+        let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 1)
+        let button = element.children(matching: .button).element(boundBy: 0)
+        button.tap()
+        
+        sleep(4)
+        
+        XCTAssertEqual(element.exists, false, "Controls are visible.")
+    }
+    
+    func testTapVideoWhenControlsHidden_ShouldShowControls() {
+        let element = XCUIApplication().children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element
+        let button = element.children(matching: .other).element(boundBy: 1).children(matching: .button).element(boundBy: 0)
+        button.tap()
+        
+        sleep(4)
+        
+        element.children(matching: .other).element(boundBy: 0).tap()
+        
+        XCTAssertEqual(element.exists, true, "Controls are not visible.")
+    }
 }

--- a/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
+++ b/Example/ASPVideoPlayer_ExampleUITests/ASPVideoPlayer_ExampleUITests.swift
@@ -38,7 +38,7 @@ class ASPVideoPlayer_ExampleUITests: XCTestCase {
         XCTAssertEqual(button.isSelected, true, "Button is not selected.")
     }
     
-    func testAdjustScrubber_ShouldSeekVideo() {
+    func testDragScrubber_ShouldSeekVideo() {
         let app = XCUIApplication()
         let element = app.children(matching: .window).element(boundBy: 0)
         let labelValue = app.staticTexts.element(boundBy: 0)
@@ -51,6 +51,17 @@ class ASPVideoPlayer_ExampleUITests: XCTestCase {
         let destinationCoordinate: XCUICoordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 1.0))
         
         startCoordinate.press(forDuration: 0.0, thenDragTo: destinationCoordinate)
+        
+        XCTAssertNotEqual(labelValue.label, "00:00:00", "Values are equal.")
+        XCTAssertNotEqual(labelValue.label, "00:00", "Values are equal.")
+    }
+    
+    func testTapScrubber_ShouldSeekVideo() {
+        let app = XCUIApplication()
+        let labelValue = app.staticTexts.element(boundBy: 0)
+        
+        // Tap scrubber
+        app.children(matching: .window).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 1).children(matching: .other).element(boundBy: 1).tap()
         
         XCTAssertNotEqual(labelValue.label, "00:00:00", "Values are equal.")
         XCTAssertNotEqual(labelValue.label, "00:00", "Values are equal.")

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 		677B46737A023F79C64A03E47D94AF6C /* Pods-ASPVideoPlayer_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ASPVideoPlayer_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		75093D7E1D14C1210054E08D /* AnimationForwarder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationForwarder.swift; sourceTree = "<group>"; };
 		75093D7F1D14C1210054E08D /* ASPVideoPlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASPVideoPlayerView.swift; sourceTree = "<group>"; };
-		75093D801D14C1210054E08D /* ASPVideoPlayerControls.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASPVideoPlayerControls.swift; sourceTree = "<group>"; };
+		75093D801D14C1210054E08D /* ASPVideoPlayerControls.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASPVideoPlayerControls.swift; sourceTree = "<group>"; usesTabs = 1; };
 		75140AD51E02BF680007BF95 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		753C6F131E01256B00D8D697 /* Loader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		75A472761DFA04B800F459E9 /* PlayPauseLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayPauseLayer.swift; sourceTree = "<group>"; };

--- a/Example/Tests/ASPTestCase.swift
+++ b/Example/Tests/ASPTestCase.swift
@@ -1,0 +1,27 @@
+//
+//  ASPTestCase.swift
+//  ASPVideoPlayer
+//
+//  Created by Rob Phillips on 4/14/17.
+//  Copyright (c) 2017 Andrei-Sergiu Pitis. All rights reserved.
+//
+
+import XCTest
+
+class ASPTestCase: XCTestCase {
+    
+    func asp_expectation(description: String) -> XCTestExpectation {
+        let expectation = super.expectation(description: description)
+        expectation.assertForOverFulfill = false
+        return expectation
+    }
+    
+    func asp_waitForExpectations(timeout: TimeInterval = 5) {
+        waitForExpectations(timeout: timeout) { (error) in
+            if let error = error {
+                print(error)
+            }
+        }
+    }
+
+}

--- a/Example/Tests/ASPTestCase.swift
+++ b/Example/Tests/ASPTestCase.swift
@@ -23,5 +23,5 @@ class ASPTestCase: XCTestCase {
             }
         }
     }
-
+    
 }

--- a/Example/Tests/ASPVideoPlayerControlsTests.swift
+++ b/Example/Tests/ASPVideoPlayerControlsTests.swift
@@ -10,219 +10,219 @@ import XCTest
 @testable import ASPVideoPlayer
 
 class ASPVideoPlayerControlsTests: ASPTestCase {
-	
-	let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
-	
-	override func setUp() {
-		super.setUp()
-	}
-	
-	override func tearDown() {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-		super.tearDown()
-	}
-	
-	func testInitPlayerControler_ShouldSetWeakReferenceToVideoPlayer() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		XCTAssertEqual(sut.videoPlayer, videoPlayer, "Players are equal.")
-	}
-	
-	func testSetNextButtonHidden_ShouldHideNextButton() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.nextButtonHidden = true
-		
-		XCTAssertEqual(sut.nextButtonHidden, true, "Next button is not hidden.")
-	}
-	
-	func testSetPreviousButtonHidden_ShouldHidePreviousButton() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.previousButtonHidden = true
-		
-		XCTAssertEqual(sut.previousButtonHidden, true, "Next button is not hidden.")
-	}
-	
-	func testSetInteracting_ShouldCallInteractingClosure() {
+    
+    let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testInitPlayerControler_ShouldSetWeakReferenceToVideoPlayer() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        XCTAssertEqual(sut.videoPlayer, videoPlayer, "Players are equal.")
+    }
+    
+    func testSetNextButtonHidden_ShouldHideNextButton() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.nextButtonHidden = true
+        
+        XCTAssertEqual(sut.nextButtonHidden, true, "Next button is not hidden.")
+    }
+    
+    func testSetPreviousButtonHidden_ShouldHidePreviousButton() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.previousButtonHidden = true
+        
+        XCTAssertEqual(sut.previousButtonHidden, true, "Next button is not hidden.")
+    }
+    
+    func testSetInteracting_ShouldCallInteractingClosure() {
         let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.interacting = { (isInteracting) in
-			XCTAssertTrue(isInteracting, "Interacting is false.")
-			expectation.fulfill()
-		}
-		
-		sut.isInteracting = true
+        
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.interacting = { (isInteracting) in
+            XCTAssertTrue(isInteracting, "Interacting is false.")
+            expectation.fulfill()
+        }
+        
+        sut.isInteracting = true
         
         asp_waitForExpectations()
-	}
-	
-	func testApplicationDidEnterBackgroundReceived_ShouldPauseVideo() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.play()
-
-		NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
-		
-		XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
-	}
-	
-	func testVideoStoppedAndPlayButtonPressed_ShouldPlayVideo() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.playButtonPressed()
-		
-		XCTAssertEqual(sut.videoPlayer?.status, .playing, "Video is not playing.")
-	}
-	
-	func testVideoPlayingAndPlayButtonPressed_ShouldPauseVideo() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.play()
-		
-		sut.playButtonPressed()
-		
-		XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
-	}
-	
-	func testNextButtonPressed_DidPressNextButton() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.didPressNextButton = {
-			expectation.fulfill()
-		}
-		
-		sut.nextButtonPressed()
-		
-		asp_waitForExpectations()
-	}
-	
-	func testPreviousButtonPressed_DidPressPreviousButton() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.didPressPreviousButton = {
-			expectation.fulfill()
-		}
-		
-		sut.previousButtonPressed()
-		
-		asp_waitForExpectations()
-	}
-	
-	func testProgressSliderBeginTouch_ShouldSetInteraction() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.interacting = { (isInteracting) in
-			XCTAssertTrue(isInteracting, "Interacting is false.")
-			expectation.fulfill()
-		}
-		
-		sut.progressSliderBeginTouch()
-		
-		asp_waitForExpectations()
-	}
-	
-	func testProgressSliderEndTouch_ShouldSetInteraction() {
-		let videoPlayer = ASPVideoPlayerView()
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		let slider = Scrubber()
-		slider.value = 0.5
-		
-		sut.progressSliderChanged(slider: slider)
-		
-		XCTAssertEqual(sut.videoPlayer?.progress, Double(slider.value), "Values are not equal.")
-	}
-	
-	func testPlayCalled_ShoudStartVideoPlayback() {
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.play()
-		
-		XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-	}
-	
-	func testPauseCalled_ShouldPauseVideoPlayback() {
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.pause()
-		
-		XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.paused, "Video is paused.")
-	}
-	
-	func testStopCalled_ShouldStopVideoPlayback() {
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.stop()
-		
-		XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.stopped, "Video is stopped.")
-	}
- 
-	func testJumpForwardCalled_ShouldJumpVideoPlaybackForward() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
-			videoPlayer?.seek(0.5)
-			let initialProgress = videoPlayer?.progress
-			
-			sut.jumpForward()
-			
-			XCTAssertGreaterThan(sut.videoPlayer?.progress ?? 0, initialProgress!, "Video jumped forwards.")
-			expectation.fulfill()
-		}
-		
-		asp_waitForExpectations()
-	}
-	
-	func testJumpBackwardCalled_ShouldJumpVideoPlaybackBackward() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
-			videoPlayer?.seek(0.5)
-			let initialProgress = videoPlayer?.progress
-			
-			sut.jumpBackward()
-			
-			XCTAssertLessThan(sut.videoPlayer?.progress ?? 1, initialProgress!, "Video jumped backwards.")
-			expectation.fulfill()
-		}
-		
-		asp_waitForExpectations()
-	}
-	
-	func testVolumeSet_ShouldChangeVolumeToNewValue () {
+    }
+    
+    func testApplicationDidEnterBackgroundReceived_ShouldPauseVideo() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.play()
+        
+        NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
+        
+        XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
+    }
+    
+    func testVideoStoppedAndPlayButtonPressed_ShouldPlayVideo() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.playButtonPressed()
+        
+        XCTAssertEqual(sut.videoPlayer?.status, .playing, "Video is not playing.")
+    }
+    
+    func testVideoPlayingAndPlayButtonPressed_ShouldPauseVideo() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.play()
+        
+        sut.playButtonPressed()
+        
+        XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
+    }
+    
+    func testNextButtonPressed_DidPressNextButton() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.didPressNextButton = {
+            expectation.fulfill()
+        }
+        
+        sut.nextButtonPressed()
+        
+        asp_waitForExpectations()
+    }
+    
+    func testPreviousButtonPressed_DidPressPreviousButton() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.didPressPreviousButton = {
+            expectation.fulfill()
+        }
+        
+        sut.previousButtonPressed()
+        
+        asp_waitForExpectations()
+    }
+    
+    func testProgressSliderBeginTouch_ShouldSetInteraction() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.interacting = { (isInteracting) in
+            XCTAssertTrue(isInteracting, "Interacting is false.")
+            expectation.fulfill()
+        }
+        
+        sut.progressSliderBeginTouch()
+        
+        asp_waitForExpectations()
+    }
+    
+    func testProgressSliderEndTouch_ShouldSetInteraction() {
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        let slider = Scrubber()
+        slider.value = 0.5
+        
+        sut.progressSliderChanged(slider: slider)
+        
+        XCTAssertEqual(sut.videoPlayer?.progress, Double(slider.value), "Values are not equal.")
+    }
+    
+    func testPlayCalled_ShoudStartVideoPlayback() {
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.play()
+        
+        XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
+    }
+    
+    func testPauseCalled_ShouldPauseVideoPlayback() {
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.pause()
+        
+        XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.paused, "Video is paused.")
+    }
+    
+    func testStopCalled_ShouldStopVideoPlayback() {
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        sut.stop()
+        
+        XCTAssertEqual(sut.videoPlayer?.status, ASPVideoPlayerView.PlayerStatus.stopped, "Video is stopped.")
+    }
+    
+    func testJumpForwardCalled_ShouldJumpVideoPlaybackForward() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
+            videoPlayer?.seek(0.5)
+            let initialProgress = videoPlayer?.progress
+            
+            sut.jumpForward()
+            
+            XCTAssertGreaterThan(sut.videoPlayer?.progress ?? 0, initialProgress!, "Video jumped forwards.")
+            expectation.fulfill()
+        }
+        
+        asp_waitForExpectations()
+    }
+    
+    func testJumpBackwardCalled_ShouldJumpVideoPlaybackBackward() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
+            videoPlayer?.seek(0.5)
+            let initialProgress = videoPlayer?.progress
+            
+            sut.jumpBackward()
+            
+            XCTAssertLessThan(sut.videoPlayer?.progress ?? 1, initialProgress!, "Video jumped backwards.")
+            expectation.fulfill()
+        }
+        
+        asp_waitForExpectations()
+    }
+    
+    func testVolumeSet_ShouldChangeVolumeToNewValue () {
         let expectation = self.asp_expectation(description: #function)
         
         let videoPlayer = ASPVideoPlayerView()
@@ -238,30 +238,30 @@ class ASPVideoPlayerControlsTests: ASPTestCase {
         videoPlayer.videoURL = self.videoURL
         
         asp_waitForExpectations()
-	}
-	
-	func testSeekToSpecificLocation_ShouldSeekVideoToPercentage() {
-		let expectation = self.asp_expectation(description: #function)
-		
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		let minimumValue = 0.0
-		let maximumValue = 3.0
-		let value = 1.5
-		
-		videoPlayer.seekEnded = {
-			let progress = sut.videoPlayer?.progress
-			
-			XCTAssertEqual(progress, 0.5, "Video set to specified percentage.")
-			expectation.fulfill()
-		}
-		
-		videoPlayer.readyToPlayVideo = {
-			sut.seek(min: minimumValue, max: maximumValue, value: value)
-		}
-		
-		asp_waitForExpectations()
-	}
+    }
+    
+    func testSeekToSpecificLocation_ShouldSeekVideoToPercentage() {
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        videoPlayer.videoURL = videoURL
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        let minimumValue = 0.0
+        let maximumValue = 3.0
+        let value = 1.5
+        
+        videoPlayer.seekEnded = {
+            let progress = sut.videoPlayer?.progress
+            
+            XCTAssertEqual(progress, 0.5, "Video set to specified percentage.")
+            expectation.fulfill()
+        }
+        
+        videoPlayer.readyToPlayVideo = {
+            sut.seek(min: minimumValue, max: maximumValue, value: value)
+        }
+        
+        asp_waitForExpectations()
+    }
 }

--- a/Example/Tests/ASPVideoPlayerControlsTests.swift
+++ b/Example/Tests/ASPVideoPlayerControlsTests.swift
@@ -9,14 +9,12 @@
 import XCTest
 @testable import ASPVideoPlayer
 
-class ASPVideoPlayerControlsTests: XCTestCase {
+class ASPVideoPlayerControlsTests: ASPTestCase {
 	
-	var videoURL: URL!
+	let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
 	
 	override func setUp() {
 		super.setUp()
-		
-		videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
 	}
 	
 	override func tearDown() {
@@ -24,7 +22,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		super.tearDown()
 	}
 	
-	func testInitPlayerControler_ShouldSetWeakReferenceToViedeoPlayer() {
+	func testInitPlayerControler_ShouldSetWeakReferenceToVideoPlayer() {
 		let videoPlayer = ASPVideoPlayerView()
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
 		
@@ -50,7 +48,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 	}
 	
 	func testSetInteracting_ShouldCallInteractingClosure() {
-		let expectation = self.expectation(description: "Timeout expectation")
+        let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
@@ -61,12 +59,8 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		}
 		
 		sut.isInteracting = true
-		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+        
+        asp_waitForExpectations()
 	}
 	
 	func testApplicationDidEnterBackgroundReceived_ShouldPauseVideo() {
@@ -77,7 +71,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 
 		NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
 		
-		XCTAssertEqual(videoPlayer.status, .paused, "Video is not paused.")
+		XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
 	}
 	
 	func testVideoStoppedAndPlayButtonPressed_ShouldPlayVideo() {
@@ -86,7 +80,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.playButtonPressed()
 		
-		XCTAssertEqual(videoPlayer.status, .playing, "Video is not playing.")
+		XCTAssertEqual(sut.videoPlayer?.status, .playing, "Video is not playing.")
 	}
 	
 	func testVideoPlayingAndPlayButtonPressed_ShouldPauseVideo() {
@@ -97,11 +91,11 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.playButtonPressed()
 		
-		XCTAssertEqual(videoPlayer.status, .paused, "Video is not paused.")
+		XCTAssertEqual(sut.videoPlayer?.status, .paused, "Video is not paused.")
 	}
 	
 	func testNextButtonPressed_DidPressNextButton() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
@@ -112,15 +106,11 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.nextButtonPressed()
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 	
 	func testPreviousButtonPressed_DidPressPreviousButton() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
@@ -131,15 +121,11 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.previousButtonPressed()
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 	
 	func testProgressSliderBeginTouch_ShouldSetInteraction() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
@@ -151,11 +137,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.progressSliderBeginTouch()
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 	
 	func testProgressSliderEndTouch_ShouldSetInteraction() {
@@ -167,7 +149,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		
 		sut.progressSliderChanged(slider: slider)
 		
-		XCTAssertEqual(sut.videoPlayer!.progress, Double(slider.value), "Values are not equal.")
+		XCTAssertEqual(sut.videoPlayer?.progress, Double(slider.value), "Values are not equal.")
 	}
 	
 	func testPlayCalled_ShoudStartVideoPlayback() {
@@ -201,65 +183,65 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 	}
  
 	func testJumpForwardCalled_ShouldJumpVideoPlaybackForward() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		videoPlayer.videoURL = videoURL
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
 		
-		videoPlayer.readyToPlayVideo = {
-			videoPlayer.seek(0.5)
-			let initialProgress = videoPlayer.progress
+		videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
+			videoPlayer?.seek(0.5)
+			let initialProgress = videoPlayer?.progress
 			
 			sut.jumpForward()
 			
-			XCTAssertGreaterThan(sut.videoPlayer!.progress, initialProgress, "Video jumped forwards.")
+			XCTAssertGreaterThan(sut.videoPlayer?.progress ?? 0, initialProgress!, "Video jumped forwards.")
 			expectation.fulfill()
 		}
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 	
 	func testJumpBackwardCalled_ShouldJumpVideoPlaybackBackward() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		videoPlayer.videoURL = videoURL
 		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
 		
-		videoPlayer.readyToPlayVideo = {
-			videoPlayer.seek(0.5)
-			let initialProgress = videoPlayer.progress
+		videoPlayer.readyToPlayVideo = { [weak videoPlayer] in
+			videoPlayer?.seek(0.5)
+			let initialProgress = videoPlayer?.progress
 			
 			sut.jumpBackward()
 			
-			XCTAssertLessThan(sut.videoPlayer!.progress, initialProgress, "Video jumped backwards.")
+			XCTAssertLessThan(sut.videoPlayer?.progress ?? 1, initialProgress!, "Video jumped backwards.")
 			expectation.fulfill()
 		}
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 	
 	func testVolumeSet_ShouldChangeVolumeToNewValue () {
-		let videoPlayer = ASPVideoPlayerView()
-		videoPlayer.videoURL = videoURL
-		let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
-		
-		sut.volume(0.5)
-		
-		XCTAssertEqual(sut.videoPlayer!.volume, 0.5, "Video volume set.")
+        let expectation = self.asp_expectation(description: #function)
+        
+        let videoPlayer = ASPVideoPlayerView()
+        let sut = ASPVideoPlayerControls(videoPlayer: videoPlayer)
+        
+        videoPlayer.readyToPlayVideo = {
+            sut.volume(0.5)
+            
+            XCTAssertEqual(sut.videoPlayer?.volume, 0.5, "Video volume set.")
+            expectation.fulfill()
+        }
+        
+        videoPlayer.videoURL = self.videoURL
+        
+        asp_waitForExpectations()
 	}
 	
 	func testSeekToSpecificLocation_ShouldSeekVideoToPercentage() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.asp_expectation(description: #function)
 		
 		let videoPlayer = ASPVideoPlayerView()
 		videoPlayer.videoURL = videoURL
@@ -270,7 +252,7 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 		let value = 1.5
 		
 		videoPlayer.seekEnded = {
-			let progress = sut.videoPlayer!.progress
+			let progress = sut.videoPlayer?.progress
 			
 			XCTAssertEqual(progress, 0.5, "Video set to specified percentage.")
 			expectation.fulfill()
@@ -280,10 +262,6 @@ class ASPVideoPlayerControlsTests: XCTestCase {
 			sut.seek(min: minimumValue, max: maximumValue, value: value)
 		}
 		
-		waitForExpectations(timeout: 5.0) { (error) in
-			if let error = error {
-				print(error)
-			}
-		}
+		asp_waitForExpectations()
 	}
 }

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -39,6 +39,15 @@ class ASPVideoPlayerTests: XCTestCase {
 		XCTAssertEqual(sut.videoPlayerView.shouldLoop, true, "Player shouldLoop not set correctly.")
 	}
 	
+    func testSetVideoURL_ShouldSetVideoURL() {
+        let sut = ASPVideoPlayer()
+        
+        sut.videoURL = videoURL
+        
+        XCTAssertEqual(sut.videoURLs.first, videoURL, "Player URLs not set correctly.")
+        XCTAssertEqual(sut.videoURLs.count, 1, "Player URLs not set correctly.")
+    }
+    
 	func testSetVideoURLs_ShouldSetVideoURLs() {
 		let sut = ASPVideoPlayer()
 		

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -9,14 +9,12 @@
 import XCTest
 @testable import ASPVideoPlayer
 
-class ASPVideoPlayerTests: XCTestCase {
+class ASPVideoPlayerTests: ASPTestCase {
         
-	var videoURL: URL!
+	let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
 	
 	override func setUp() {
 		super.setUp()
-		
-		videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")
 	}
 	
 	override func tearDown() {
@@ -26,17 +24,17 @@ class ASPVideoPlayerTests: XCTestCase {
 	func testSetGravity_ShouldSetGravity() {
 		let sut = ASPVideoPlayer()
 		
-		sut.videoPlayerView.gravity = .resize
+		sut.videoPlayerView?.gravity = .resize
 		
-		XCTAssertEqual(sut.videoPlayerView.gravity, .resize, "Player gravity not set correctly.")
+		XCTAssertEqual(sut.videoPlayerView?.gravity, .resize, "Player gravity not set correctly.")
 	}
 	
 	func testSetShouldLoop_ShouldSetShouldLoop() {
 		let sut = ASPVideoPlayer()
 		
-		sut.videoPlayerView.shouldLoop = true
+		sut.videoPlayerView?.shouldLoop = true
 		
-		XCTAssertEqual(sut.videoPlayerView.shouldLoop, true, "Player shouldLoop not set correctly.")
+		XCTAssertEqual(sut.videoPlayerView?.shouldLoop, true, "Player shouldLoop not set correctly.")
 	}
 	
     func testSetVideoURL_ShouldSetVideoURL() {
@@ -63,25 +61,25 @@ class ASPVideoPlayerTests: XCTestCase {
 		sut.tintColor = UIColor.blue
 		
 		XCTAssertEqual(sut.tintColor, UIColor.blue, "Player tint color not set correctly.")
-		XCTAssertEqual(sut.tintColor, sut.videoPlayerControls.tintColor, "Player tint color not set correctly.")
+		XCTAssertEqual(sut.tintColor, sut.videoPlayerControls?.tintColor, "Player tint color not set correctly.")
 	}
 	
 	func testControlsVisibleAndPlayerStarting_ShouldHideControls() {
 		let sut = ASPVideoPlayer()
 		sut.videoURL = videoURL
-		sut.videoPlayerControls.play()
+		sut.videoPlayerControls?.play()
 
-		XCTAssertEqual(sut.videoPlayerControls.alpha, 0.0, "Player controls are visible.")
+		XCTAssertEqual(sut.videoPlayerControls?.alpha, 0.0, "Player controls are visible.")
 	}
 	
 	func testControlsHiddenAndPlayerRunningToggleControls_ShouldShowControls() {
 		let sut = ASPVideoPlayer()
 		sut.videoURL = videoURL
-		sut.videoPlayerControls.play()
+		sut.videoPlayerControls?.play()
 		sut.hideControls()
 		
 		sut.toggleControls()
 
-		XCTAssertEqual(sut.videoPlayerControls.alpha, 1.0, "Player controls are not visible.")
+		XCTAssertEqual(sut.videoPlayerControls?.alpha, 1.0, "Player controls are not visible.")
 	}
 }

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -10,33 +10,33 @@ import XCTest
 @testable import ASPVideoPlayer
 
 class ASPVideoPlayerTests: ASPTestCase {
+    
+    let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testSetGravity_ShouldSetGravity() {
+        let sut = ASPVideoPlayer()
         
-	let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
-	
-	override func setUp() {
-		super.setUp()
-	}
-	
-	override func tearDown() {
-		super.tearDown()
-	}
-	
-	func testSetGravity_ShouldSetGravity() {
-		let sut = ASPVideoPlayer()
-		
-		sut.videoPlayerView?.gravity = .resize
-		
-		XCTAssertEqual(sut.videoPlayerView?.gravity, .resize, "Player gravity not set correctly.")
-	}
-	
-	func testSetShouldLoop_ShouldSetShouldLoop() {
-		let sut = ASPVideoPlayer()
-		
-		sut.videoPlayerView?.shouldLoop = true
-		
-		XCTAssertEqual(sut.videoPlayerView?.shouldLoop, true, "Player shouldLoop not set correctly.")
-	}
-	
+        sut.videoPlayerView?.gravity = .resize
+        
+        XCTAssertEqual(sut.videoPlayerView?.gravity, .resize, "Player gravity not set correctly.")
+    }
+    
+    func testSetShouldLoop_ShouldSetShouldLoop() {
+        let sut = ASPVideoPlayer()
+        
+        sut.videoPlayerView?.shouldLoop = true
+        
+        XCTAssertEqual(sut.videoPlayerView?.shouldLoop, true, "Player shouldLoop not set correctly.")
+    }
+    
     func testSetVideoURL_ShouldSetVideoURL() {
         let sut = ASPVideoPlayer()
         
@@ -46,40 +46,40 @@ class ASPVideoPlayerTests: ASPTestCase {
         XCTAssertEqual(sut.videoURLs.count, 1, "Player URLs not set correctly.")
     }
     
-	func testSetVideoURLs_ShouldSetVideoURLs() {
-		let sut = ASPVideoPlayer()
-		
-		sut.videoURLs = [videoURL]
-		
-		XCTAssertEqual(sut.videoURLs.first, videoURL, "Player URLs not set correctly.")
-		XCTAssertEqual(sut.videoURLs.count, 1, "Player URLs not set correctly.")
-	}
-	
-	func testSetTintColor_ShouldSetTintColorForVideoControls() {
-		let sut = ASPVideoPlayer()
-		
-		sut.tintColor = UIColor.blue
-		
-		XCTAssertEqual(sut.tintColor, UIColor.blue, "Player tint color not set correctly.")
-		XCTAssertEqual(sut.tintColor, sut.videoPlayerControls?.tintColor, "Player tint color not set correctly.")
-	}
-	
-	func testControlsVisibleAndPlayerStarting_ShouldHideControls() {
-		let sut = ASPVideoPlayer()
-		sut.videoURL = videoURL
-		sut.videoPlayerControls?.play()
-
-		XCTAssertEqual(sut.videoPlayerControls?.alpha, 0.0, "Player controls are visible.")
-	}
-	
-	func testControlsHiddenAndPlayerRunningToggleControls_ShouldShowControls() {
-		let sut = ASPVideoPlayer()
-		sut.videoURL = videoURL
-		sut.videoPlayerControls?.play()
-		sut.hideControls()
-		
-		sut.toggleControls()
-
-		XCTAssertEqual(sut.videoPlayerControls?.alpha, 1.0, "Player controls are not visible.")
-	}
+    func testSetVideoURLs_ShouldSetVideoURLs() {
+        let sut = ASPVideoPlayer()
+        
+        sut.videoURLs = [videoURL]
+        
+        XCTAssertEqual(sut.videoURLs.first, videoURL, "Player URLs not set correctly.")
+        XCTAssertEqual(sut.videoURLs.count, 1, "Player URLs not set correctly.")
+    }
+    
+    func testSetTintColor_ShouldSetTintColorForVideoControls() {
+        let sut = ASPVideoPlayer()
+        
+        sut.tintColor = UIColor.blue
+        
+        XCTAssertEqual(sut.tintColor, UIColor.blue, "Player tint color not set correctly.")
+        XCTAssertEqual(sut.tintColor, sut.videoPlayerControls?.tintColor, "Player tint color not set correctly.")
+    }
+    
+    func testControlsVisibleAndPlayerStarting_ShouldHideControls() {
+        let sut = ASPVideoPlayer()
+        sut.videoURL = videoURL
+        sut.videoPlayerControls?.play()
+        
+        XCTAssertEqual(sut.videoPlayerControls?.alpha, 0.0, "Player controls are visible.")
+    }
+    
+    func testControlsHiddenAndPlayerRunningToggleControls_ShouldShowControls() {
+        let sut = ASPVideoPlayer()
+        sut.videoURL = videoURL
+        sut.videoPlayerControls?.play()
+        sut.hideControls()
+        
+        sut.toggleControls()
+        
+        XCTAssertEqual(sut.videoPlayerControls?.alpha, 1.0, "Player controls are not visible.")
+    }
 }

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -36,7 +36,15 @@ class ASPVideoPlayerTests: ASPTestCase {
         
         XCTAssertEqual(sut.videoPlayerView?.shouldLoop, true, "Player shouldLoop not set correctly.")
     }
-    
+	
+	func testSetControlsInitiallyHidden_ShouldSetControlsInitiallyHidden() {
+		let sut = ASPVideoPlayer()
+		
+		sut.controlsInitiallyHidden = true
+		
+		XCTAssertEqual(sut.controlsInitiallyHidden, true, "Player controlsInitiallyHidden not set correctly.")
+	}
+	
     func testSetVideoURL_ShouldSetVideoURL() {
         let sut = ASPVideoPlayer()
         
@@ -71,7 +79,25 @@ class ASPVideoPlayerTests: ASPTestCase {
         
         XCTAssertEqual(sut.videoPlayerControls?.alpha, 0.0, "Player controls are visible.")
     }
-    
+	
+	func testControlsInitiallyHidden_ShouldHideControlsInitially() {
+		let sut = ASPVideoPlayer()
+		
+		sut.controlsInitiallyHidden = true
+		sut.videoURL = videoURL
+		
+		XCTAssertEqual(sut.videoPlayerControls?.alpha, 0.0, "Player controls are not visible.")
+	}
+	
+	func testControlsNotInitiallyHidden_ShouldShowControlsInitially() {
+		let sut = ASPVideoPlayer()
+		
+		sut.controlsInitiallyHidden = false
+		sut.videoURL = videoURL
+		
+		XCTAssertEqual(sut.videoPlayerControls?.alpha, 1.0, "Player controls are visible.")
+	}
+	
     func testControlsHiddenAndPlayerRunningToggleControls_ShouldShowControls() {
         let sut = ASPVideoPlayer()
         sut.videoURL = videoURL

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -66,18 +66,17 @@ class ASPVideoPlayerTests: XCTestCase {
 		XCTAssertEqual(sut.tintColor, sut.videoPlayerControls.tintColor, "Player tint color not set correctly.")
 	}
 	
-	func testControlsVisibleAndPlayerRunningToggleControls_ShouldHideControls() {
+	func testControlsVisibleAndPlayerStarting_ShouldHideControls() {
 		let sut = ASPVideoPlayer()
-		sut.videoURLs = [videoURL]
+		sut.videoURL = videoURL
 		sut.videoPlayerControls.play()
-		sut.toggleControls()
 
 		XCTAssertEqual(sut.videoPlayerControls.alpha, 0.0, "Player controls are visible.")
 	}
 	
 	func testControlsHiddenAndPlayerRunningToggleControls_ShouldShowControls() {
 		let sut = ASPVideoPlayer()
-		sut.videoURLs = [videoURL]
+		sut.videoURL = videoURL
 		sut.videoPlayerControls.play()
 		sut.hideControls()
 		

--- a/Example/Tests/ASPVideoPlayerTests.swift
+++ b/Example/Tests/ASPVideoPlayerTests.swift
@@ -26,17 +26,17 @@ class ASPVideoPlayerTests: XCTestCase {
 	func testSetGravity_ShouldSetGravity() {
 		let sut = ASPVideoPlayer()
 		
-		sut.gravity = .resize
+		sut.videoPlayerView.gravity = .resize
 		
-		XCTAssertEqual(sut.gravity, .resize, "Player gravity not set correctly.")
+		XCTAssertEqual(sut.videoPlayerView.gravity, .resize, "Player gravity not set correctly.")
 	}
 	
 	func testSetShouldLoop_ShouldSetShouldLoop() {
 		let sut = ASPVideoPlayer()
 		
-		sut.shouldLoop = true
+		sut.videoPlayerView.shouldLoop = true
 		
-		XCTAssertEqual(sut.shouldLoop, true, "Player shouldLoop not set correctly.")
+		XCTAssertEqual(sut.videoPlayerView.shouldLoop, true, "Player shouldLoop not set correctly.")
 	}
 	
 	func testSetVideoURLs_ShouldSetVideoURLs() {

--- a/Example/Tests/ASPVideoPlayerViewTests.swift
+++ b/Example/Tests/ASPVideoPlayerViewTests.swift
@@ -243,25 +243,6 @@ class ASPVideoPlayerViewTests: ASPTestCase {
         asp_waitForExpectations()
     }
     
-    func testPlayFinishedVideo_ShouldStartVideoPlaybackFromBeginning() {
-        let expectation = self.asp_expectation(description: #function)
-        
-        let player = ASPVideoPlayerView()
-        player.readyToPlayVideo = { [weak player] in
-            player?.playingVideo = { (progress) in
-                XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-                player?.stopVideo()
-                expectation.fulfill()
-            }
-            
-            player?.playVideo()
-        }
-        
-        player.videoURL = videoURL
-        
-        asp_waitForExpectations()
-    }
-    
     func testStopVideo_ShouldStopVideo() {
         let expectation = self.asp_expectation(description: #function)
         

--- a/Example/Tests/ASPVideoPlayerViewTests.swift
+++ b/Example/Tests/ASPVideoPlayerViewTests.swift
@@ -10,34 +10,34 @@ import XCTest
 @testable import ASPVideoPlayer
 
 class ASPVideoPlayerViewTests: ASPTestCase {
-	
+    
     let videoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")!
     let secondVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4")!
     let invalidVideoURL = Bundle.main.url(forResource: "video3", withExtension: "mp4")
-	
-	override func setUp() {
-		super.setUp()
-	}
-	
-	override func tearDown() {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-		super.tearDown()
-	}
-	
-	func testInitWithFrame_ShouldCreatePlayerWithFrame() {
-		let frame = CGRect(x: 0.0, y: 0.0, width: 10.0, height: 10.0)
-		let player = ASPVideoPlayerView(frame: frame)
-		
-		XCTAssertEqual(player.frame, frame, "Frames are equal.")
-	}
-	
-	func testDeinitCalled_ShouldDeallocatePlayer() {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testInitWithFrame_ShouldCreatePlayerWithFrame() {
+        let frame = CGRect(x: 0.0, y: 0.0, width: 10.0, height: 10.0)
+        let player = ASPVideoPlayerView(frame: frame)
+        
+        XCTAssertEqual(player.frame, frame, "Frames are equal.")
+    }
+    
+    func testDeinitCalled_ShouldDeallocatePlayer() {
         weak var player = ASPVideoPlayerView()
         
-		XCTAssertNil(player, "Player deallocated.")
-	}
-	
-	func testSetVolumeAboveMaximum_ShouldSetPlayerVolumeToMaximum() {
+        XCTAssertNil(player, "Player deallocated.")
+    }
+    
+    func testSetVolumeAboveMaximum_ShouldSetPlayerVolumeToMaximum() {
         let expectation = self.asp_expectation(description: #function)
         
         let player = ASPVideoPlayerView()
@@ -51,9 +51,9 @@ class ASPVideoPlayerViewTests: ASPTestCase {
         }
         
         asp_waitForExpectations()
-	}
-	
-	func testSetVolumeBelowMinimum_ShouldSetPlayerVolumeToMinimum() {
+    }
+    
+    func testSetVolumeBelowMinimum_ShouldSetPlayerVolumeToMinimum() {
         let expectation = self.asp_expectation(description: #function)
         
         let player = ASPVideoPlayerView()
@@ -67,93 +67,93 @@ class ASPVideoPlayerViewTests: ASPTestCase {
         }
         
         asp_waitForExpectations()
-	}
-	
-	func testSetVolumeURLNotSet_ShouldSetPlayerVolumeToMinimum() {
-		let player = ASPVideoPlayerView()
-		
-		player.volume = -1.0
-		
-		XCTAssertEqual(player.volume, 0.0, "Volume set to minimum.")
-	}
-	
-	func testSetGravityAspectFill_ShouldChangeGravityToAspectFill() {
-		let player = ASPVideoPlayerView()
-		
-		player.gravity = .aspectFill
-		
-		XCTAssertEqual(player.gravity, ASPVideoPlayerView.PlayerContentMode.aspectFill, "Content Mode is AspectFill.")
-	}
-	
-	func testSetGravityResize_ShouldChangeGravityToResize() {
-		let player = ASPVideoPlayerView()
-		
-		player.gravity = .resize
-		
-		XCTAssertEqual(player.gravity, ASPVideoPlayerView.PlayerContentMode.resize, "Content Mode is Resize.")
-	}
-	
-	func testLoadInvalidURL_ShouldChangeStateToError() {
-		let player = ASPVideoPlayerView()
-		player.error = { [weak player] (error) in
-			XCTAssertNil(player?.videoURL, "Video URL is nil.")
-			XCTAssertEqual(error.localizedDescription, "Video URL is invalid (can't be nil).")
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.error)
-		}
-		player.videoURL = invalidVideoURL
-	}
-	
-	func testLoadInvalidURL_ShouldReturnZeroForCurrentTime() {
+    }
+    
+    func testSetVolumeURLNotSet_ShouldSetPlayerVolumeToMinimum() {
+        let player = ASPVideoPlayerView()
+        
+        player.volume = -1.0
+        
+        XCTAssertEqual(player.volume, 0.0, "Volume set to minimum.")
+    }
+    
+    func testSetGravityAspectFill_ShouldChangeGravityToAspectFill() {
+        let player = ASPVideoPlayerView()
+        
+        player.gravity = .aspectFill
+        
+        XCTAssertEqual(player.gravity, ASPVideoPlayerView.PlayerContentMode.aspectFill, "Content Mode is AspectFill.")
+    }
+    
+    func testSetGravityResize_ShouldChangeGravityToResize() {
+        let player = ASPVideoPlayerView()
+        
+        player.gravity = .resize
+        
+        XCTAssertEqual(player.gravity, ASPVideoPlayerView.PlayerContentMode.resize, "Content Mode is Resize.")
+    }
+    
+    func testLoadInvalidURL_ShouldChangeStateToError() {
+        let player = ASPVideoPlayerView()
+        player.error = { [weak player] (error) in
+            XCTAssertNil(player?.videoURL, "Video URL is nil.")
+            XCTAssertEqual(error.localizedDescription, "Video URL is invalid (can't be nil).")
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.error)
+        }
+        player.videoURL = invalidVideoURL
+    }
+    
+    func testLoadInvalidURL_ShouldReturnZeroForCurrentTime() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		
-		player.error = { [weak player] error in
-			XCTAssertEqual(player?.currentTime, 0.0, "Current Time is Zero")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = invalidVideoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testLoadInvalidURL_ShouldReturnZeroForVideoLength() {
+        let player = ASPVideoPlayerView()
+        
+        player.error = { [weak player] error in
+            XCTAssertEqual(player?.currentTime, 0.0, "Current Time is Zero")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = invalidVideoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testLoadInvalidURL_ShouldReturnZeroForVideoLength() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		
-		player.error = { [weak player] error in
-			XCTAssertEqual(player?.videoLength, 0.0, "Video Length is Zero")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = invalidVideoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testLoadVideoURL_ShouldLoadVideoAtURL() {
+        let player = ASPVideoPlayerView()
+        
+        player.error = { [weak player] error in
+            XCTAssertEqual(player?.videoLength, 0.0, "Video Length is Zero")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = invalidVideoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testLoadVideoURL_ShouldLoadVideoAtURL() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.newVideo = { [weak player] in
+        let player = ASPVideoPlayerView()
+        player.newVideo = { [weak player] in
             XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.new)
-			XCTAssertNotNil(player?.videoURL, "Video URL is not nil.")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testLoadNewVideoURL_ShouldLoadVideoAtURL() {
+            XCTAssertNotNil(player?.videoURL, "Video URL is not nil.")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testLoadNewVideoURL_ShouldLoadVideoAtURL() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		
-		player.readyToPlayVideo = { [weak player] in
+        let player = ASPVideoPlayerView()
+        
+        player.readyToPlayVideo = { [weak player] in
             player?.newVideo = {
                 XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.new)
                 XCTAssertEqual(player?.videoURL, self.secondVideoURL)
@@ -161,141 +161,141 @@ class ASPVideoPlayerViewTests: ASPTestCase {
             }
             
             player?.videoURL = self.secondVideoURL
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testLoadVideoAndStartPlayingWhenReadySet_ShouldChangeStateToPlaying() {
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testLoadVideoAndStartPlayingWhenReadySet_ShouldChangeStateToPlaying() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		
-		player.startPlayingWhenReady = true
-		
-		player.startedVideo = { [weak player] in
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-		
-	func testSeekToPercentageBelowMinimum_ShouldSetCurrentTimeToZero() {
+        let player = ASPVideoPlayerView()
+        
+        player.startPlayingWhenReady = true
+        
+        player.startedVideo = { [weak player] in
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testSeekToPercentageBelowMinimum_ShouldSetCurrentTimeToZero() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.readyToPlayVideo = { [weak player] in
-			player?.seek(-1.0)
-			player?.pauseVideo()
-		}
-		
-		player.pausedVideo = { [weak player] in
-			XCTAssertEqual(player?.currentTime, 0.0, "Current Time is Zero")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-		
-	func testPlayVideo_ShouldStartVideoPlayback() {
+        let player = ASPVideoPlayerView()
+        player.readyToPlayVideo = { [weak player] in
+            player?.seek(-1.0)
+            player?.pauseVideo()
+        }
+        
+        player.pausedVideo = { [weak player] in
+            XCTAssertEqual(player?.currentTime, 0.0, "Current Time is Zero")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testPlayVideo_ShouldStartVideoPlayback() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.startPlayingWhenReady = true
-		
-		player.playingVideo = { [weak player] (progress) in
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-			player?.stopVideo()
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testPlayVideoThatIsAtMaximumPercentage_ShouldStartVideoPlaybackFromStartOfVideo() {
+        let player = ASPVideoPlayerView()
+        player.startPlayingWhenReady = true
+        
+        player.playingVideo = { [weak player] (progress) in
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
+            player?.stopVideo()
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testPlayVideoThatIsAtMaximumPercentage_ShouldStartVideoPlaybackFromStartOfVideo() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.readyToPlayVideo = { [weak player] in
-			player?.seek(1.0)
-			player?.playVideo()
-		}
-		
-		player.startedVideo = { [weak player] in
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-			XCTAssertEqual(player?.progress, 0.0, "Progress is Zero")
-			
-			player?.stopVideo()
-			expectation.fulfill()
-		}
-
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testPlayFinishedVideo_ShouldStartVideoPlaybackFromBeginning() {
+        let player = ASPVideoPlayerView()
+        player.readyToPlayVideo = { [weak player] in
+            player?.seek(1.0)
+            player?.playVideo()
+        }
+        
+        player.startedVideo = { [weak player] in
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
+            XCTAssertEqual(player?.progress, 0.0, "Progress is Zero")
+            
+            player?.stopVideo()
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testPlayFinishedVideo_ShouldStartVideoPlaybackFromBeginning() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.readyToPlayVideo = { [weak player] in
+        let player = ASPVideoPlayerView()
+        player.readyToPlayVideo = { [weak player] in
             player?.playingVideo = { (progress) in
                 XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
                 player?.stopVideo()
                 expectation.fulfill()
             }
             
-			player?.playVideo()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testStopVideo_ShouldStopVideo() {
+            player?.playVideo()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testStopVideo_ShouldStopVideo() {
         let expectation = self.asp_expectation(description: #function)
         
         let player = ASPVideoPlayerView()
-		player.startPlayingWhenReady = true
-
-		player.playingVideo = { [weak player] (progress) in
-			player?.stopVideo()
-		}
-		
-		player.stoppedVideo = { [weak player] in
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.stopped, "Video playback has stopped.")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-		
-		asp_waitForExpectations()
-	}
-	
-	func testShouldLoopSet_ShouldLoopVideoWhenFinished() {
+        player.startPlayingWhenReady = true
+        
+        player.playingVideo = { [weak player] (progress) in
+            player?.stopVideo()
+        }
+        
+        player.stoppedVideo = { [weak player] in
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.stopped, "Video playback has stopped.")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations()
+    }
+    
+    func testShouldLoopSet_ShouldLoopVideoWhenFinished() {
         let expectation = self.asp_expectation(description: #function)
         
-		let player = ASPVideoPlayerView()
-		player.shouldLoop = true
-		player.startPlayingWhenReady = true
-		
-		player.finishedVideo = { [weak player] in
-			XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
-			expectation.fulfill()
-		}
-		
-		player.videoURL = videoURL
-
-		asp_waitForExpectations(timeout: 20)
-	}
+        let player = ASPVideoPlayerView()
+        player.shouldLoop = true
+        player.startPlayingWhenReady = true
+        
+        player.finishedVideo = { [weak player] in
+            XCTAssertEqual(player?.status, ASPVideoPlayerView.PlayerStatus.playing, "Video is playing.")
+            expectation.fulfill()
+        }
+        
+        player.videoURL = videoURL
+        
+        asp_waitForExpectations(timeout: 20)
+    }
 }

--- a/Example/Tests/ASPVideoPlayerViewTests.swift
+++ b/Example/Tests/ASPVideoPlayerViewTests.swift
@@ -85,14 +85,14 @@ class ASPVideoPlayerViewTests: XCTestCase {
 		let player = ASPVideoPlayerView()
 		player.error = { (error) in
 			XCTAssertNil(player.videoURL, "Video URL is nil.")
-			XCTAssertEqual(error.localizedDescription, "Video URL is invalid.")
+			XCTAssertEqual(error.localizedDescription, "Video URL is invalid (can't be nil).")
 			XCTAssertEqual(player.status, ASPVideoPlayerView.PlayerStatus.error)
 		}
 		player.videoURL = invalidVideoURL
 	}
 	
 	func testLoadInvalidURL_ShouldReturnZeroForCurrentTime() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.expectation(description: "Current time should be zero")
 		
 		let player = ASPVideoPlayerView()
 		
@@ -111,7 +111,7 @@ class ASPVideoPlayerViewTests: XCTestCase {
 	}
 	
 	func testLoadInvalidURL_ShouldReturnZeroForVideoLength() {
-		let expectation = self.expectation(description: "Timeout expectation")
+		let expectation = self.expectation(description: "Video length should be zero")
 		
 		let player = ASPVideoPlayerView()
 		

--- a/Example/Tests/ViewControllerTests.swift
+++ b/Example/Tests/ViewControllerTests.swift
@@ -21,26 +21,10 @@ class ViewControllerTests: XCTestCase {
     
 	func testViewControllerViewCreated_ShouldLoadViewController() {
 		let storyboard = UIStoryboard(name: "Main", bundle: nil)
-		let sut = storyboard.instantiateViewController(withIdentifier: "ASPPlayerViewViewController") as! ViewController
-		let view = sut.view
-		
-		sut.videoPlayer.newVideo?()
-		
-		sut.videoPlayer.readyToPlayVideo?()
-		
-		sut.videoPlayer.startedVideo?()
-		
-		sut.videoPlayer.finishedVideo?()
-		
-		sut.videoPlayer.playingVideo?(0.0)
-		
-		sut.videoPlayer.pausedVideo?()
-		
-		sut.videoPlayer.stoppedVideo?()
-		
-		sut.videoPlayer.error?(NSError(domain: "test", code: 999, userInfo: nil))
+		let sut = storyboard.instantiateViewController(withIdentifier: "ASPPlayerViewViewController") as? ViewController
+		let view = sut?.view
 
 		XCTAssertNotNil(view, "View is not nil.")
-		XCTAssertNotNil(sut.videoPlayer, "Video player is not nil.")
+		XCTAssertNotNil(sut?.videoPlayer, "Video player is not nil.")
 	}
 }

--- a/Example/Tests/ViewControllerTests.swift
+++ b/Example/Tests/ViewControllerTests.swift
@@ -10,21 +10,21 @@ import XCTest
 @testable import ASPVideoPlayer_Example
 
 class ViewControllerTests: XCTestCase {
-        
-	override func setUp() {
-		super.setUp()
-	}
-	
-	override func tearDown() {
-		super.tearDown()
-	}
     
-	func testViewControllerViewCreated_ShouldLoadViewController() {
-		let storyboard = UIStoryboard(name: "Main", bundle: nil)
-		let sut = storyboard.instantiateViewController(withIdentifier: "ASPPlayerViewViewController") as? ViewController
-		let view = sut?.view
-
-		XCTAssertNotNil(view, "View is not nil.")
-		XCTAssertNotNil(sut?.videoPlayer, "Video player is not nil.")
-	}
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testViewControllerViewCreated_ShouldLoadViewController() {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let sut = storyboard.instantiateViewController(withIdentifier: "ASPPlayerViewViewController") as? ViewController
+        let view = sut?.view
+        
+        XCTAssertNotNil(view, "View is not nil.")
+        XCTAssertNotNil(sut?.videoPlayer, "Video player is not nil.")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ let videoPlayer = ASPVideoPlayer()
 @IBOutlet weak var videoPlayer: ASPVideoPlayer!
 ```
 
-- Once you have the reference, you can set the video URLs, the gravity and wether the videos should loop:
+- Once you have the reference, you can set the video URLs, the gravity and whether the videos should loop:
 
 ```swift
 let firstVideoURL = Bundle.main.url(forResource: "video", withExtension: "mp4")

--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ let secondVideoURL = Bundle.main.url(forResource: "video2", withExtension: "mp4"
 
 videoPlayer.videoURLs = [firstVideoURL!, secondVideoURL!]
 
-videoPlayer.gravity = .aspectFit
+// You can also access all properties and functions using the underlying 
+// `videoPlayerView` property that backs this view (see below for detail)
 
-videoPlayer.shouldLoop = true
+videoPlayer.videoPlayerView.gravity = .aspectFit
+
+videoPlayer.videoPlayerView.shouldLoop = true
 ```
 
 ### 2. ASPVideoPlayerView

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let videoPlayer = ASPVideoPlayer()
 - You can also instantiate it from Interface Builder and create an IBOutlet:
 
 ```swift
-@IBOutlet weak var videoPlayer: ASPVideoPlayer!
+@IBOutlet weak var videoPlayer: ASPVideoPlayer?
 ```
 
 - Once you have the reference, you can set the video URLs, the gravity and whether the videos should loop:
@@ -71,7 +71,7 @@ let videoPlayer = ASPVideoPlayerView()
 - You can also instantiate it from Interface Builder and create an IBOutlet:
 
 ```swift
-@IBOutlet weak var videoPlayer: ASPVideoPlayerView!
+@IBOutlet weak var videoPlayer: ASPVideoPlayerView?
 ```
 
 - Once you have the reference, you can set a video url and use the closures to handle different events:


### PR DESCRIPTION
Hey @andreipitis 👋 

I've decided to use this video player in a production application and found some issues while digging through and testing it out. I did not change the external API very much (view the [updated README](https://github.com/iwasrobbed/ASPVideoPlayer/blob/cb/README.md) for the minimal changes).

If you'd rather not have these changes, I'm fine with forking off as well; just let me know but figured I'd try and give back.

Todo:
- [ ] There are some pre-existing scrubber bugs where it jumps around a lot when scrubbing and letting go. I'll look into those sometime soon
- [ ] Add more test coverage

Changes (based on commit msgs):
- ✅ Allow a custom font to be set for the time labels
- ✅ Only show hours in the time if there are any hours to show
- ✅ Expose the underlying `videoPlayerView` within `videoPlayer` so we can access the closure callbacks
- ✅ Expose a `videoURL` setter
- ✅ Ensure `startPlayingWhenReady` hides controls when used on the UI player w/ controls
- ✅ Move previous/next logic down into the videoPlayerView and create a queue for handling that
- ✅ Add buffering callbacks and some error handling, such as `AVPlayerItemFailedToPlayToEndTime` notification
- ✅ Assets are now loaded asynchronously ([mandatory on iOS](https://developer.apple.com/reference/avfoundation/avasynchronouskeyvalueloading))
- ✅ Fix tests for async changes and removed `!` bang operators everywhere except tests since it was causing some difficult-to-find `EXC_BAD_ACCESS` issues in the example app; it's safer to use an optional var with a `guard` pattern here
- ✅ Make scrubber also change value when tapped
- ✅ Fixed all retain cycles so the player gets released from memory (there were quite a few areas strongly held and memory kept growing each time)
- ✅ Ensure the progress loader stops animating correctly
- ✅ Only show the progress loader after ~0.5s have passed so it doesn't show a blip on faster network connections
- ✅ Allow multiple subscribers for closures (similar to delegates, overwriting an existing closure value meant you lost any existing implementation/callback so it was causing strange behavior)
- ✅ Add a `controlsInitiallyHidden` property w/ tests (default = false)

Caution:
- Going forward, tests will have to be written with an asynchronous approach since assets can load either async or sync depending on if they've already been loaded (default `AVAsset` behavior).
  - This means some tests could pass locally and then fail on travis or another machine, so it's something to keep in mind.
- The way all these setters are calling each other while also allowing multiple subscribers for closures means it's hard to debug at times. Might be best to rethink in a deterministic manner